### PR TITLE
Acceptor send learns

### DIFF
--- a/paxos-wasm/agents/Cargo.toml
+++ b/paxos-wasm/agents/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
+edition = "2024"
 name = "agents"
 version = "0.1.0"
-edition = "2024"
+
+[dependencies]
 
 [build-dependencies]
-paxos-wasm-utils = { path = "../shared/utils" }
-core = { path = "../core" }
+core = {path = "../core"}
+paxos-wasm-utils = {path = "../shared/utils"}

--- a/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
+++ b/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
@@ -75,6 +75,34 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
         self.acceptor.accept(slot, ballot, &value)
     }
 
+    fn retry_learn(&self, slot: Slot, from: Node) {
+        logger::log_info(&format!(
+            "[Acceptor Agent] Retrying learn for slot {}",
+            slot
+        ));
+
+        let value: Value;
+
+        if let Some(pvalue) = self.acceptor.get_accepted(slot) {
+            // Have accepted value, just send it back to messsage sender
+            value = pvalue.value.unwrap(); // should be safe to unwrap ??
+        } else {
+            // No accepted value for this slot, missing from proposer, send noop to learn to ensure progress
+            value = Value {
+                command: None,
+                client_id: "".to_string(),
+                client_seq: 0,
+            };
+        }
+
+        let learn = Learn { slot, value };
+
+        let learn_msg = NetworkMessage {
+            sender: self.node.clone(),
+            payload: MessagePayload::Learn(learn.clone()),
+        };
+        _ = network::send_message(&vec![from], &learn_msg);
+    }
     // Commit phase: broadcasts a learn message if configured to do so.
     fn commit_phase(&self, slot: Slot, value: Value) -> Option<Learn> {
         if self.config.acceptors_send_learns {
@@ -93,7 +121,7 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
                 sender: self.node.clone(),
                 payload: MessagePayload::Learn(learn.clone()),
             };
-            _ = network::send_message(&vec![], &learn_msg);
+            _ = network::send_message(&self.learners, &learn_msg);
             Some(learn)
         } else {
             logger::log_warn(
@@ -141,10 +169,10 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
             MessagePayload::Accept(payload) => {
                 logger::log_info(&format!(
                     "[Acceptor Agent] Handling ACCEPT: slot={}, ballot={}, value={:?}",
-                    payload.slot, payload.ballot, payload.value
+                    payload.slot, payload.ballot, &payload.value
                 ));
                 let accepted_result =
-                    self.process_accept(payload.slot, payload.ballot, payload.value);
+                    self.process_accept(payload.slot, payload.ballot, payload.value.clone());
                 let response = match accepted_result {
                     AcceptedResult::Accepted(accepted) => {
                         let msg = NetworkMessage {
@@ -152,9 +180,22 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
                             payload: MessagePayload::Accepted(accepted),
                         };
 
-                        //* Fire-and-forget */
-                        if self.config.is_event_driven {
-                            network::send_message_forget(&vec![message.sender.clone()], &msg);
+                        if self.config.acceptors_send_learns {
+                            let learn = Learn {
+                                slot: accepted.slot,
+                                value: payload.value,
+                            };
+
+                            let learn_msg = NetworkMessage {
+                                sender: self.node.clone(),
+                                payload: MessagePayload::Learn(learn.clone()),
+                            };
+                            _ = network::send_message(&self.learners, &learn_msg);
+                        } else {
+                            if self.config.is_event_driven {
+                                //* Fire-and-forget */
+                                network::send_message_forget(&vec![message.sender.clone()], &msg);
+                            }
                         }
                         msg
                     }
@@ -164,6 +205,19 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
                     },
                 };
                 response
+            }
+            MessagePayload::RetryLearn(slot) => {
+                logger::log_warn(&format!(
+                    "[Acceptor Agent] Handling LEARN RETRY: slots={:?}",
+                    slot
+                ));
+
+                self.retry_learn(slot, message.sender);
+
+                NetworkMessage {
+                    sender: self.node.clone(),
+                    payload: MessagePayload::Ignore,
+                }
             }
             MessagePayload::Heartbeat(payload) => {
                 logger::log_debug(&format!(

--- a/paxos-wasm/agents/proposer-agent/Cargo.toml
+++ b/paxos-wasm/agents/proposer-agent/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
+edition = "2024"
 name = "proposer-agent"
 version = "0.1.0"
-edition = "2024"
 
 [lib]
-path = "src/proposer-agent.rs"
 crate-type = ["cdylib"]
+path = "src/proposer-agent.rs"
 
 [dependencies]
+rand = "0.8"
 wit-bindgen = "0.41"

--- a/paxos-wasm/core/acceptor/src/acceptor.rs
+++ b/paxos-wasm/core/acceptor/src/acceptor.rs
@@ -150,16 +150,14 @@ impl GuestAcceptorResource for MyAcceptorResource {
                 });
             } else if existing.value == Some(value.clone()) {
                 // this could happen on leader failure where leader proposes values from promises to get them executed
-                // the leader could probably directly commit such a value but then we cant use them in the 
+                // the leader could probably directly commit such a value but then we cant use them in the
                 // priority queue as we have now
                 return AcceptedResult::Accepted(Accepted {
                     slot,
                     ballot,
                     success: true,
                 });
-            }
-            
-            else {
+            } else {
                 // A conflicting proposal exists for this slot; reject the new request.
                 logger::log_warn(&format!(
                     "[Core Acceptor] Rejected accept for slot {} with ballot {} because a conflicting proposal already exists (existing ballot: {}, value: {:?})",
@@ -186,6 +184,10 @@ impl GuestAcceptorResource for MyAcceptorResource {
                 success: true,
             });
         }
+    }
+
+    fn get_accepted(&self, slot: Slot) -> Option<PValue> {
+        self.accepted.borrow().get(&slot).cloned()
     }
 
     /// Returns the current state: lists of promise entries and accepted proposals.

--- a/paxos-wasm/core/learner/Cargo.toml
+++ b/paxos-wasm/core/learner/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
+edition = "2024"
 name = "learner"
 version = "0.1.0"
-edition = "2024"
 
 [lib]
-path = "src/learner.rs"
 crate-type = ["cdylib"]
+path = "src/learner.rs"
 
 [dependencies]
 wit-bindgen = "0.41"

--- a/paxos-wasm/core/learner/src/learner.rs
+++ b/paxos-wasm/core/learner/src/learner.rs
@@ -1,5 +1,6 @@
 use std::cell::{Cell, RefCell};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant};
 
 mod bindings {
     wit_bindgen::generate!({
@@ -10,14 +11,14 @@ mod bindings {
 
 bindings::export!(MyLearner with_types_in bindings);
 
-use bindings::paxos::default::paxos_types::{Slot, Value};
+use bindings::paxos::default::paxos_types::{Accepted, Learn, Node, Slot, Value};
 
 use crate::bindings::exports::paxos::default::learner::{
     Guest, GuestLearnerResource, LearnResult, LearnedEntry, LearnerState,
 };
 use crate::bindings::paxos::default::logger;
 
-struct MyLearner;
+pub struct MyLearner;
 
 impl Guest for MyLearner {
     type LearnerResource = MyLearnerResource;
@@ -25,12 +26,29 @@ impl Guest for MyLearner {
 
 /// Our learner now uses a BTreeMap to store learned values per slot.
 /// This ensures that each slot only has one learned value and that the entries remain ordered.
-struct MyLearnerResource {
+pub struct MyLearnerResource {
     learned: RefCell<BTreeMap<Slot, Value>>,
     next_to_execute: Cell<Slot>,
     execution_log: RefCell<BTreeMap<Slot, Value>>,
     // executed_order: RefCell<Vec<LearnedEntry>>,
     max_gap_size: u64,
+    slot_learns: RefCell<BTreeMap<Slot, HashMap<u64, Learn>>>,
+    // slots_chosen: RefCell<BTreeMap<Slot, Learn>>,
+    quorum: usize,
+
+    flush_timout: Duration,
+    last_flush: Cell<Instant>,
+
+    rety_timeout: Duration,
+    last_message_recieved: Cell<Instant>,
+}
+
+impl MyLearnerResource {
+    fn learn_equals(&self, l1: &Learn, l2: &Learn) -> bool {
+        l1.slot == l2.slot
+            && l1.value.client_id == l2.value.client_id
+            && l1.value.client_seq == l2.value.client_seq
+    }
 }
 
 impl GuestLearnerResource for MyLearnerResource {
@@ -41,7 +59,15 @@ impl GuestLearnerResource for MyLearnerResource {
             next_to_execute: Cell::new(1),
             execution_log: RefCell::new(BTreeMap::new()),
             // executed_order: RefCell::new(Vec::new()),
-            max_gap_size: 10,
+            max_gap_size: 1,
+            slot_learns: RefCell::new(BTreeMap::new()),
+            // slots_chosen: RefCell::new(BTreeMap::new()),
+            quorum: 2, // Hardcoded for now, but should be set by the config
+            flush_timout: Duration::from_millis(10),
+            last_flush: Cell::new(Instant::now()),
+
+            rety_timeout: Duration::from_millis(500),
+            last_message_recieved: Cell::new(Instant::now()),
         }
     }
 
@@ -64,49 +90,126 @@ impl GuestLearnerResource for MyLearnerResource {
         self.next_to_execute.get()
     }
 
+    // Handles incoming learns from acceptors. Checks for quorum and and stores the learned value. Returns ready to be executed slots if any
+    fn handle_learn(&self, learn: Learn, from: Node) -> LearnResult {
+        {
+            let now = Instant::now();
+            self.last_message_recieved.set(now);
+            let execution_log = self.execution_log.borrow();
+            if !execution_log.contains_key(&learn.slot) {
+                logger::log_info(&format!(
+                    "[Core Learner]: Received learn for slot {} from node {}",
+                    learn.slot, from.node_id
+                ));
+                let slot = learn.slot;
+                self.slot_learns
+                    .borrow_mut()
+                    .entry(slot)
+                    .or_insert_with(HashMap::new)
+                    .insert(from.node_id, learn.clone());
+
+                if let Some(sender_map) = self.slot_learns.borrow().get(&slot) {
+                    if sender_map.len() >= self.quorum {
+                        let learns: Vec<&Learn> = sender_map.values().collect();
+
+                        for &candidate in &learns {
+                            let count = learns
+                                .iter()
+                                .filter(|&&learn| self.learn_equals(learn, candidate))
+                                .count();
+
+                            if count >= self.quorum {
+                                logger::log_info(&format!(
+                                    "Learner: Learned full Learn {:?} for slot {} with count {}",
+                                    candidate, slot, count
+                                ));
+                                // Learn: candidate.value or the full candidate
+                                self.learned
+                                    .borrow_mut()
+                                    .insert(slot, candidate.value.clone());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        self.to_be_executed()
+    }
+
+    fn to_be_executed(&self) -> LearnResult {
+        let mut learned_map = self.learned.borrow_mut();
+        let mut next_to_execute = self.get_next_to_execute();
+
+        let mut contiguous_ready = 0;
+        let mut probe_slot = next_to_execute;
+
+        // First just *count* how many contiguous slots are ready
+        while learned_map.contains_key(&probe_slot) {
+            contiguous_ready += 1;
+            probe_slot += 1;
+
+            if contiguous_ready >= 10 {
+                // Tcp socket problems if message is to big. Also noticed increadbly slowdowns when sending 20+ slots
+                break;
+            }
+        }
+
+        let now = Instant::now();
+
+        // Alwasys send out between 5 and 10 slots or if the timeout has passed
+        if contiguous_ready >= 5 || now.duration_since(self.last_flush.get()) > self.flush_timout {
+            let mut to_be_executed = Vec::new();
+            let mut execution_log = self.execution_log.borrow_mut();
+
+            // Now actually remove and execute them
+            for _ in 0..contiguous_ready {
+                if let Some(val) = learned_map.remove(&next_to_execute) {
+                    execution_log.insert(next_to_execute, val.clone());
+                    to_be_executed.push(LearnedEntry {
+                        slot: next_to_execute,
+                        value: val,
+                    });
+                    next_to_execute += 1;
+                    self.next_to_execute.set(next_to_execute);
+                }
+            }
+            self.last_flush.set(now);
+
+            return LearnResult::Execute(to_be_executed);
+        } else {
+            LearnResult::Ignore
+        }
+        // Check if some learns are ready to
+    }
     // TODO: Take into account the client-id and client_seq when executing, and not just the slot
 
     /// Record that a value has been learned for a given slot.
     /// If the slot already has a learned value, a warning is logged and the new value is ignored.
     /// Can only execute consecutive slots starting from the next_to_execute slot.
     fn learn(&self, slot: Slot, value: Value) -> LearnResult {
-        let mut learned_map = self.learned.borrow_mut();
-        let mut next_to_execute = self.get_next_to_execute();
-        let mut execution_log = self.execution_log.borrow_mut();
+        {
+            let mut learned_map = self.learned.borrow_mut();
+            let execution_log = self.execution_log.borrow_mut();
 
-        // Insert learn if have not learned yet
-        if !learned_map.contains_key(&slot) && !execution_log.contains_key(&slot) {
-            logger::log_info(&format!(
-                "[Core Learner]: For slot {}, learned value {:?}",
-                slot, value
-            ));
-            learned_map.insert(slot, value);
-        } else {
-            logger::log_warn(&format!(
-                "Learner: Slot {} already has a learned value. Ignoring new value {:?}.",
-                slot, value
-            ));
+            // Insert learn if have not learned yet
+            if !learned_map.contains_key(&slot) && !execution_log.contains_key(&slot) {
+                logger::log_info(&format!(
+                    "[Core Learner]: For slot {}, learned value {:?}",
+                    slot, value
+                ));
+                learned_map.insert(slot, value);
+            } else {
+                logger::log_warn(&format!(
+                    "Learner: Slot {} already has a learned value. Ignoring new value {:?}.",
+                    slot, value
+                ));
+            }
         }
 
         // Check if some learns are ready to be executed in order
-        let mut to_be_executed = Vec::new();
-        if learned_map.contains_key(&next_to_execute) {
-            // Execute as many contiguous slots as possible.
-            while let Some(val) = learned_map.remove(&next_to_execute) {
-                execution_log.insert(next_to_execute, val.clone());
-                to_be_executed.push(LearnedEntry {
-                    slot: next_to_execute,
-                    value: val.clone(),
-                });
-
-                next_to_execute += 1;
-                self.next_to_execute.set(next_to_execute);
-            }
-
-            return LearnResult::Execute(to_be_executed);
-        } else {
-            LearnResult::Ignore
-        }
+        self.to_be_executed()
     }
 
     // Checker for gaps in the learned slots. Should be called at reasoinable a interval.
@@ -128,8 +231,11 @@ impl GuestLearnerResource for MyLearnerResource {
         // Compute the gap between the maximum learned slot and the next expected one.
         let gap = max_learned_slot - next_to_execute;
 
+        let now = Instant::now();
         // Only return a gap if it exceeds the maximum allowed gap size.
-        if gap > self.max_gap_size {
+        if gap >= self.max_gap_size
+            || (gap > 0 && now.duration_since(self.last_message_recieved.get()) > self.rety_timeout)
+        {
             Some(next_to_execute)
         } else {
             None

--- a/paxos-wasm/core/proposer/src/proposer.rs
+++ b/paxos-wasm/core/proposer/src/proposer.rs
@@ -355,20 +355,6 @@ impl GuestProposerResource for MyProposerResource {
             .filter(|a| a.slot == prop.slot && a.ballot == prop.ballot && a.success)
             .count();
 
-        // TODO: Fix this, if we want to ensure submitted client request will eventually get committed.
-        // if count >= self.num_acceptors as usize {
-        //     logger::log_debug(&format!(
-        //         "[Core Proposer] Accept phase failed for slot {}. All acceptors answered.",
-        //         slot
-        //     ));
-        //     self.prioritized_values.borrow_mut().push_back(PValue {
-        //         // TODO: Add back to queue as just a Value?
-        //         slot: slot,
-        //         ballot: self.current_ballot.get(),
-        //         value: Some(prop.value.clone()),
-        //     });
-        // }
-
         if count < self.quorum() as usize {
             logger::log_debug(&format!(
                 "[Core Proposer] Accept phase failed for slot {}: {} acceptances received (quorum is {}).",
@@ -417,15 +403,16 @@ impl GuestProposerResource for MyProposerResource {
 
     /// Marks a commit‐pending proposal “finalized” once it has executed.
     fn mark_proposal_finalized(&self, slot: Slot) -> Option<Value> {
+        // swithc between infligh for acceptors send learns and commit pending for the rest
         if self
-            .get_proposal_by_status(slot, ProposalStatus::CommitPending)
+            .get_proposal_by_status(slot, ProposalStatus::InFlight)
             .is_none()
         {
-            let curr = self.proposals.borrow().get(&slot).map(|e| e.status.clone());
-            logger::log_error(&format!(
-                "[Proposer] Cannot finalize slot {} in status {:?}; expected CommitPending.",
-                slot, curr
-            ));
+            // let curr = self.proposals.borrow().get(&slot).map(|e| e.status.clone());
+            // logger::log_error(&format!(
+            //     "[Proposer] Cannot finalize slot {} in status {:?}; expected CommitPending.",
+            //     slot, curr
+            // ));
             return None;
         }
 
@@ -436,6 +423,26 @@ impl GuestProposerResource for MyProposerResource {
             slot, val
         ));
         Some(val)
+    }
+
+    /// Marks and inflight proposal finalized and retires the proposal for new slot
+    fn mark_proposal_finalized_and_retry(&self, slot: Slot) -> Option<Value> {
+        if let Some(prop) = self.get_proposal_by_status(slot, ProposalStatus::InFlight) {
+            let val = self.update_proposal_status(slot, ProposalStatus::Finalized)?;
+            logger::log_info(&format!(
+                "[Proposer] Proposal slot {} marked Finalized with noop: {:?} and retrying with new slot.",
+                slot, &val
+            ));
+            self.enqueue_client_request(prop.value.clone());
+            Some(prop.value)
+        } else {
+            // logger::log_error(&format!(
+            //     "[Proposer] Cannot finalize slot {} in status {:?}; expected InFlight.",
+            //     slot,
+            //     self.proposals.borrow().get(&slot).map(|e| e.status.clone())
+            // ));
+            None
+        }
     }
 
     fn increase_ballot(&self) -> Ballot {

--- a/paxos-wasm/core/proposer/src/proposer.rs
+++ b/paxos-wasm/core/proposer/src/proposer.rs
@@ -408,11 +408,6 @@ impl GuestProposerResource for MyProposerResource {
             .get_proposal_by_status(slot, ProposalStatus::InFlight)
             .is_none()
         {
-            // let curr = self.proposals.borrow().get(&slot).map(|e| e.status.clone());
-            // logger::log_error(&format!(
-            //     "[Proposer] Cannot finalize slot {} in status {:?}; expected CommitPending.",
-            //     slot, curr
-            // ));
             return None;
         }
 
@@ -423,26 +418,6 @@ impl GuestProposerResource for MyProposerResource {
             slot, val
         ));
         Some(val)
-    }
-
-    /// Marks and inflight proposal finalized and retires the proposal for new slot
-    fn mark_proposal_finalized_and_retry(&self, slot: Slot) -> Option<Value> {
-        if let Some(prop) = self.get_proposal_by_status(slot, ProposalStatus::InFlight) {
-            let val = self.update_proposal_status(slot, ProposalStatus::Finalized)?;
-            logger::log_info(&format!(
-                "[Proposer] Proposal slot {} marked Finalized with noop: {:?} and retrying with new slot.",
-                slot, &val
-            ));
-            self.enqueue_client_request(prop.value.clone());
-            Some(prop.value)
-        } else {
-            // logger::log_error(&format!(
-            //     "[Proposer] Cannot finalize slot {} in status {:?}; expected InFlight.",
-            //     slot,
-            //     self.proposals.borrow().get(&slot).map(|e| e.status.clone())
-            // ));
-            None
-        }
     }
 
     fn increase_ballot(&self) -> Ballot {

--- a/paxos-wasm/modular-ws-test/demo-client-ws.sh
+++ b/paxos-wasm/modular-ws-test/demo-client-ws.sh
@@ -12,9 +12,9 @@
 # wait
 # echo "All clients finished."
 
-NUM_CLIENTS=1
-NUM_REQUESTS=500
-DEADLINE=20
+NUM_CLIENTS=10
+NUM_REQUESTS=100
+DEADLINE=100
 
 pids=()
 

--- a/paxos-wasm/modular-ws-test/paxos-client-test/src/paxos-client.rs
+++ b/paxos-wasm/modular-ws-test/paxos-client-test/src/paxos-client.rs
@@ -113,7 +113,7 @@ impl Guest for PaxosClient {
         let msg_bytes = serializer::serialize(&message);
 
         if output.write(&msg_bytes).is_ok() {
-            let timeout = Duration::from_secs(1);
+            let timeout = Duration::from_millis(5000);
             match PaxosClient::read_with_timeout(&mut input, timeout) {
                 Ok(buf) => {
                     let net_msg = serializer::deserialize(&buf);

--- a/paxos-wasm/modular-ws/src/main.rs
+++ b/paxos-wasm/modular-ws/src/main.rs
@@ -37,10 +37,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let run_config = RunConfig {
         is_event_driven: config.is_event_driven,
-        acceptors_send_learns: false,  // TODO: Hardcoded
-        learners_send_executed: false, // TODO Hardcoded for now. PLEASE FIX SOMETIME SOON :)
-        prepare_timeout: 1000,         // TODO: Hardcoded to 1 sec for now.
-        demo_client: true,
+        acceptors_send_learns: true,  // TODO: Hardcoded
+        learners_send_executed: true, // TODO Hardcoded for now. PLEASE FIX SOMETIME SOON :)
+        prepare_timeout: 1000,        // TODO: Hardcoded to 1 sec for now.
+        demo_client: false,
     };
 
     // Create the Arc<PaxosWasmtime>, making a thread safe reference to the underlying PaxosWasmtime instance

--- a/paxos-wasm/modular-ws/src/standalone_config.rs
+++ b/paxos-wasm/modular-ws/src/standalone_config.rs
@@ -39,8 +39,8 @@ impl SharedConfig {
                 Node {
                     node_id: i as u64 + 1, // Node IDs are 1-indexed
                     address: format!("{}:{}", base_ip, base_port + i as u16),
-                    // role: get_role_by_index(i),
-                    role: PaxosRole::Coordinator,
+                    role: get_role_by_index(i),
+                    // role: PaxosRole::Coordinator,
                 }
             })
             .collect();

--- a/paxos-wasm/modular-ws/tcp-server/src/tcp-server.rs
+++ b/paxos-wasm/modular-ws/tcp-server/src/tcp-server.rs
@@ -116,8 +116,8 @@ impl Runner {
                 // let _ = runner.run_paxos_loop();
                 None
             }
-            Runner::Learner(_runner) => {
-                // let _ = runner.run_paxos_loop();
+            Runner::Learner(runner) => {
+                let _ = runner.run_paxos_loop();
                 None
             }
             Runner::Coordinator(runner) => {
@@ -341,7 +341,9 @@ impl GuestWsServerResource for MyTcpServerResource {
                                     {
                                         let response_msg = NetworkMessage {
                                             sender: self.node.clone(),
-                                            payload: MessagePayload::ClientResponse(response),
+                                            payload: MessagePayload::ClientResponse(
+                                                response.clone(),
+                                            ),
                                         };
                                         let response_bytes = serializer::serialize(&response_msg);
                                         if let Err(e) = connection
@@ -356,11 +358,17 @@ impl GuestWsServerResource for MyTcpServerResource {
                                             ));
                                         } else {
                                             completed_requests += 1;
-                                            logger::log_info(
-                                                "[TCP Server] Response sent back to client.",
-                                            );
+                                            logger::log_info(&format!(
+                                                "[TCP Server] Response {:?} successfully sent back to client. Request Key: {:?}",
+                                                response, request_key,
+                                            ));
                                         }
                                         connection.shutdown();
+                                    } else {
+                                        logger::log_error(&format!(
+                                            "[TCP Server] Connection for request id {:?} is not active to send back to client.",
+                                            request_key
+                                        ));
                                     }
                                 }
                                 if last_log.elapsed() >= Duration::from_millis(500) {
@@ -420,6 +428,5 @@ fn create_listener(bind_address: &str) -> Result<TcpSocket, TcpErrorCode> {
     socket.start_listen()?;
     pollable.block();
     socket.finish_listen()?;
-
     Ok(socket)
 }

--- a/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
+++ b/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
@@ -229,9 +229,9 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
         for learn in to_commit {
             self.proposer_agent.broadcast_learn(&learn);
 
-            let executed = self
-                .learner_agent
-                .learn_and_execute(learn.slot, &learn.value);
+            let executed =
+                self.learner_agent
+                    .learn_and_execute(learn.slot, &learn.value, &self.node);
             _ = self.proposer_agent.process_executed(&executed);
         }
 

--- a/paxos-wasm/shared/wit/paxos.wit
+++ b/paxos-wasm/shared/wit/paxos.wit
@@ -40,8 +40,6 @@ interface proposer {
         /// Finalizes the proposal after learner execution
         mark-proposal-finalized: func(slot: slot) -> option<value>;
 
-        mark-proposal-finalized-and-retry: func(slot: slot) -> option<value>;
-
         // Increases ballot and returns it
         increase-ballot: func() -> ballot;
 
@@ -251,7 +249,7 @@ interface proposer-agent {
         collect-client-responses: func() -> list<client-response>;
 
         // Process the Executed from learners, and synchronously returns the created client responses 
-        process-executed: func(executed: executed) -> list<client-response>;
+        process-executed: func(executed: executed);
 
         retry-learn: func(slot: slot);
 

--- a/paxos-wasm/shared/wit/paxos.wit
+++ b/paxos-wasm/shared/wit/paxos.wit
@@ -40,6 +40,8 @@ interface proposer {
         /// Finalizes the proposal after learner execution
         mark-proposal-finalized: func(slot: slot) -> option<value>;
 
+        mark-proposal-finalized-and-retry: func(slot: slot) -> option<value>;
+
         // Increases ballot and returns it
         increase-ballot: func() -> ballot;
 
@@ -56,27 +58,31 @@ interface proposer {
 
 interface acceptor {
     use paxos-types.{slot, ballot, value, prepare, promise, accept, accepted, learn};
-    use acceptor-types.{promise-result, accepted-result, acceptor-state};
+    use acceptor-types.{promise-result, accepted-result, acceptor-state, p-value};
 
     resource acceptor-resource {
         constructor(gc-window: option<u64>);
         get-state: func() -> acceptor-state;
         prepare: func(slot: slot, ballot: ballot) -> promise-result;
         accept: func(slot: slot, ballot: ballot, value: value) -> accepted-result;
+        get-accepted: func(slot: slot) -> option<p-value>;
     }
 }
 
 interface learner {
-    use paxos-types.{slot, value};
+    use paxos-types.{slot, value, learn};
+    use network-types.{node};
     use learner-types.{learned-entry, learner-state, learn-result};
 
     resource learner-resource {
         constructor();
         get-state: func() -> learner-state;
         learn: func(slot: slot, value: value) -> learn-result;
+        handle-learn: func(learn: learn, %from: node) -> learn-result;
         get-learned: func(slot: slot) -> option<learned-entry>;
         get-next-to-execute : func() -> slot;
         check-for-gap: func() -> option<slot>;
+        to-be-executed: func() -> learn-result;
     }
 }
 
@@ -288,6 +294,8 @@ interface acceptor-agent {
         commit-phase: func(slot: slot, value: value) -> option<learn>;
 
         handle-message: func(message: network-message) -> network-message; // Note that they only care about a subset of the message types
+    
+        retry-learn: func(slot: slot, %from: node);
     }
 
 }
@@ -307,7 +315,7 @@ interface learner-agent {
         get-next-to-execute : func() -> slot;
 
         /// Learn the new value, and return a list of executed values and adu.
-        learn-and-execute: func(slot: slot, value: value) -> executed;  
+        learn-and-execute: func(slot: slot, value: value, %from: node) -> executed;  
 
         evaluate-retry: func() -> retry-learn-result;
 


### PR DESCRIPTION
- Acceptor can now send learns behind a config flag boosting performance significantly.
- Retries are handled to a certain degree:
  - If message loss between acceptor -> learner: Learner will detect and query acceptors to get their accepted messages.
  - If message loss between proposer -> acceptor: Learner will detect same as above, but now get a noop from the acceptor. When proposer detects an executed noop it reproposes the original proposal for next available slot.


TODO: 
- System can stall if message loss for request N between proposer acceptors and N was the last request in the system for a "long" time (needs N+1 to detect that something went wrong).
- No handling for the possibilites of Executed message is lost between learner -> leader proposer.

Both of these can be fixed with:
- Leader records the time it created a proposal.
- If leader has not got any executed for this proposal based on some timeout: Leader queries learners if they have commited this -> if yes, get the execute result, if not repropose orignial proposal.