### PR TITLE
Learner fixes and coordinator fixes again

### DIFF
--- a/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
+++ b/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
@@ -104,7 +104,7 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
             logger::log_warn(
                 "[Acceptor Agent] Attempted to broadcast learns, but ability not enabled.",
             );
-            None
+            panic!("Lol")
         }
     }
 

--- a/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
+++ b/paxos-wasm/agents/acceptor-agent/src/acceptor-agent.rs
@@ -108,14 +108,15 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
         }
     }
 
-    fn retry_learn(&self, slot: Slot, sender: Node) {
+    fn retry_learn(&self, slot: Slot) {
         logger::log_info(&format!(
             "[Acceptor Agent] Retrying learn for slot {}",
             slot
         ));
 
-        // Have accepted value, just send it back to message sender
-        // Otherwise, no accepted value for this slot, missing from proposer, send noop to learner to ensure progress
+        // Have accepted value, which didn't reach learner.
+        // Or, no accepted value for this slot, missing from proposer.
+        // Either get accepted value or noop.
         let value = self
             .acceptor
             .get_accepted(slot)
@@ -132,7 +133,9 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
             sender: self.node.clone(),
             payload: MessagePayload::Learn(learn.clone()),
         };
-        network::send_message_forget(&vec![sender], &learn_msg);
+
+        // Broadcasts to all learners, since if one learner need a noop, then they all should?
+        network::send_message_forget(&self.learners, &learn_msg);
     }
 
     fn handle_message(&self, message: NetworkMessage) -> NetworkMessage {
@@ -215,7 +218,7 @@ impl GuestAcceptorAgentResource for MyAcceptorAgentResource {
                     slot
                 ));
 
-                self.retry_learn(slot, message.sender);
+                self.retry_learn(slot);
 
                 NetworkMessage {
                     sender: self.node.clone(),

--- a/paxos-wasm/agents/learner-agent/src/learner-agent.rs
+++ b/paxos-wasm/agents/learner-agent/src/learner-agent.rs
@@ -1,5 +1,5 @@
-use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::cell::{Ref, RefCell};
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -19,21 +19,21 @@ use bindings::exports::paxos::default::learner_agent::{
 };
 
 use bindings::paxos::default::kv_store::KvStoreResource;
-use bindings::paxos::default::learner::LearnerResource;
-use bindings::paxos::default::learner_types::{LearnResult, LearnerState, RetryLearnResult};
+use bindings::paxos::default::learner::{LearnResult, LearnerResource};
+use bindings::paxos::default::learner_types::{LearnerState, RetryLearnResult};
 use bindings::paxos::default::network_types::{Heartbeat, MessagePayload, NetworkMessage};
 use bindings::paxos::default::paxos_types::{
-    ExecuteResult, Executed, KvPair, Learn, Node, PaxosRole, RunConfig, Slot, Value,
+    CmdResult, ExecuteResult, Executed, KvPair, Learn, Node, PaxosRole, RunConfig, Slot, Value,
 };
 use bindings::paxos::default::{logger, network};
 
-pub struct MyLearnerAgent;
+struct MyLearnerAgent;
 
 impl GuestLearnerAgent for MyLearnerAgent {
     type LearnerAgentResource = MyLearnerAgentResource;
 }
 
-pub struct MyLearnerAgentResource {
+struct MyLearnerAgentResource {
     config: RunConfig,
 
     node: Node,
@@ -42,28 +42,79 @@ pub struct MyLearnerAgentResource {
     learner: Arc<LearnerResource>,
     kv_store: Arc<KvStoreResource>,
 
+    /// for gap/timeout retries
+    last_learn_time: RefCell<Instant>,
     retries: RefCell<HashMap<Slot, Instant>>,
-    retry_interval: Duration,
+
+    /// for executions
+    exec_buffer: RefCell<VecDeque<ExecuteResult>>,
+    last_exec_time: RefCell<Instant>,
 }
 
 impl MyLearnerAgentResource {
-    fn possible_retry(&self, slot: Slot, retry_interval: Duration) -> bool {
-        match self.retries.borrow().get(&slot) {
-            Some(&last_retry_time) => {
-                // If not enough time has passed since last retry, do nothing
-                if last_retry_time.elapsed() < retry_interval {
-                    return false;
-                }
-            }
-            None => {
-                // If we have no entry, then it's the first time we retry
+    fn adu(&self) -> Slot {
+        self.get_adu()
+    }
+
+    /// Pop any newly-ready learns out of the Paxos core,
+    /// apply them to the state machine, and buffer their ExecuteResults.
+    fn execute_learns(&self) {
+        if let LearnResult::Execute(entries) = self.learner.to_be_executed() {
+            let mut buf = self.exec_buffer.borrow_mut();
+            for le in entries {
+                let cmd_res = self.kv_store.apply(&le.value.command); //* State Machine */
+                buf.push_back(ExecuteResult {
+                    slot: le.slot,
+                    value: le.value.clone(),
+                    success: !matches!(cmd_res, CmdResult::NoOp),
+                    cmd_result: cmd_res,
+                });
             }
         }
+    }
 
-        // If we reach here, we should do a retry
-        // Update the timestamp to now and return true to indicate a retry happened
-        self.retries.borrow_mut().insert(slot, Instant::now());
-        true
+    /// Collect executed results from the buffer.
+    fn collect_exec_batch(&self, batch_size: Option<u64>, require_full_batch: bool) -> Executed {
+        let mut buf = self.exec_buffer.borrow_mut();
+        // Either up to batch size or all.
+        let available = match batch_size {
+            Some(n) => buf.len().min(n as usize),
+            None => buf.len(),
+        };
+
+        // If we require a full batch (and there is a batch_size), but don't have enough, return
+        if require_full_batch && batch_size.map_or(false, |n| available < n as usize) {
+            return Executed {
+                results: Vec::new(),
+                adu: self.adu(),
+            };
+        }
+
+        // Collect exactly the available entries
+        let results: Vec<_> = buf.drain(..available).collect();
+        Executed {
+            results,
+            adu: self.adu(),
+        }
+    }
+
+    /// Dispatch any pending Executed batch to the proposers or the caller
+    fn dispatch_executed(&self, executed: Executed) -> Option<NetworkMessage> {
+        if executed.results.is_empty() || !self.config.learners_send_executed {
+            return None;
+        }
+
+        let msg = NetworkMessage {
+            sender: self.node.clone(),
+            payload: MessagePayload::Executed(executed.clone()),
+        };
+
+        if self.config.is_event_driven {
+            network::send_message_forget(&self.proposers, &msg);
+            None
+        } else {
+            Some(msg)
+        }
     }
 }
 
@@ -87,9 +138,7 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
         let learner = Arc::new(LearnerResource::new(num_acceptors));
         let kv_store = Arc::new(KvStoreResource::new());
 
-        let retry_interval = Duration::from_millis(10000); // TODO: Get from config
-
-        logger::log_info("[Learner Agent] Initialized core acceptor resource.");
+        logger::log_info("[Learner Agent] Initialized.");
         Self {
             config,
             node,
@@ -97,8 +146,10 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
             acceptors,
             learner,
             kv_store,
+            last_learn_time: RefCell::new(Instant::now()),
             retries: RefCell::new(HashMap::new()),
-            retry_interval,
+            exec_buffer: RefCell::new(VecDeque::new()),
+            last_exec_time: RefCell::new(Instant::now()),
         }
     }
 
@@ -109,84 +160,138 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
         (learner_state, kv_store_state)
     }
 
-    fn get_next_to_execute(&self) -> Slot {
-        self.learner.get_next_to_execute()
+    fn get_adu(&self) -> Slot {
+        self.learner.get_adu()
     }
 
-    // TODO
     fn learn_and_execute(&self, slot: Slot, value: Value, sender: Node) -> Executed {
-        let mut execs: Vec<ExecuteResult> = Vec::new();
-
-        if self.config.acceptors_send_learns {
-            // Just check for ready to be executed slots
+        let is_new_learn = if self.config.acceptors_send_learns {
+            // Need to save the learn from the acceptor to check for quorum before executing.
             let learn = Learn {
                 slot,
                 value: value.clone(),
             };
-
-            self.learner.handle_learn(&learn, &sender);
-
-            if let LearnResult::Execute(learns) = self.learner.to_be_executed() {
-                for le in learns {
-                    let res = self.kv_store.apply(&le.value.command);
-                    execs.push(ExecuteResult {
-                        value: le.value.clone(),
-                        slot: le.slot,
-                        success: true,
-                        cmd_result: res,
-                    });
-                }
-            }
+            self.learner.handle_learn(&learn, &sender)
         } else {
-            // Learn the slot first then check for to be executed slots
-            self.learner.learn(slot, &value);
-            if let LearnResult::Execute(learns) = self.learner.to_be_executed() {
-                for le in learns {
-                    let res = self.kv_store.apply(&le.value.command);
-                    execs.push(ExecuteResult {
-                        value: le.value.clone(),
-                        slot: le.slot,
-                        success: true,
-                        cmd_result: res,
-                    });
-                }
-            }
+            // Bypass the quorum check.
+            self.learner.learn(slot, &value)
+        };
+
+        // If no new learn, return empty
+        if !is_new_learn {
+            return Executed {
+                results: Vec::new(),
+                adu: self.adu(),
+            };
         }
 
-        let adu = self.learner.get_next_to_execute() - 1;
+        // Update timestamp and execute ready learns
+        self.last_learn_time.replace(Instant::now());
+        self.execute_learns();
 
-        Executed {
-            results: execs,
-            adu,
+        // TODO: Lol
+        if self.config.learners_send_executed {
+            // Try to collect a full batch
+            let batch = self.config.executed_batch_size;
+            let exec = self.collect_exec_batch(Some(batch), true);
+
+            if exec.results.is_empty() {
+                let buffered = self.exec_buffer.borrow().len();
+                logger::log_info(&format!(
+                    "[Learner Agent] Learned slot {}, buffered {}/{} for execution",
+                    slot, buffered, batch
+                ));
+            } else {
+                let first = exec.results.first().unwrap().slot;
+                let last = exec.results.last().unwrap().slot;
+                logger::log_info(&format!(
+                    "[Learner Agent] Executed slots {}..{} (adu={})",
+                    first,
+                    last,
+                    self.adu()
+                ));
+            }
+            exec
+        } else {
+            Executed {
+                results: vec![],
+                adu: self.adu(),
+            }
         }
     }
 
+    fn execute_and_collect(&self, max_batch: Option<u64>) -> Executed {
+        self.execute_learns();
+        let exec = self.collect_exec_batch(max_batch, false);
+
+        let buffered = self.exec_buffer.borrow().len();
+        if exec.results.is_empty() {
+            logger::log_debug(&format!(
+                "[Learner Agent] No executions ready, buffered {} for execution",
+                buffered
+            ));
+        } else {
+            let first = exec.results.first().unwrap().slot;
+            let last = exec.results.last().unwrap().slot;
+            logger::log_info(&format!(
+                "[Learner Agent] Executed slots {}..{} (adu={})",
+                first,
+                last,
+                self.adu()
+            ));
+        }
+
+        exec
+    }
+
+    /// Decide whether we need to retry learning `next`:
+    /// - NoGap: neither the gap nor timeout threshold is met
+    /// - Skip(next): threshold met but last retry for `next` was too recent
+    /// - Retry(next): threshold met and it’s been long enough since last retry
     fn evaluate_retry(&self) -> RetryLearnResult {
-        match self.learner.check_for_gap() {
-            None => RetryLearnResult::NoGap,
+        let now = Instant::now();
+        let elapsed = now.duration_since(*self.last_learn_time.borrow());
+        let timeout = Duration::from_millis(self.config.retry_interval_ms);
 
-            Some(slot) => {
-                if self.possible_retry(slot, self.retry_interval) {
-                    RetryLearnResult::Retry(slot)
-                } else {
-                    RetryLearnResult::Skip(slot)
-                }
-            }
+        if elapsed < timeout {
+            return RetryLearnResult::NoGap;
+        }
+
+        let highest = self.learner.get_highest_learned();
+        let adu = self.learner.get_adu();
+        let gap = highest.saturating_sub(adu);
+        let next = adu.saturating_add(1);
+
+        if gap < self.config.learn_max_gap {
+            return RetryLearnResult::NoGap;
+        }
+
+        // We *should* attempt a retry; but check whether we retried `next` too recently
+        let mut retries = self.retries.borrow_mut();
+        let just_retried = retries
+            .get(&next)
+            .map(|&last| now.duration_since(last) < timeout)
+            .unwrap_or(false);
+
+        if just_retried {
+            RetryLearnResult::Skip(next)
+        } else {
+            // threshold met and enough time passed → record and tell caller to retry
+            retries.insert(next, now);
+            self.last_learn_time.replace(now);
+            RetryLearnResult::Retry(next)
         }
     }
 
-    // Ticker called from host at a slower interval than proposer ticker
     fn run_paxos_loop(&self) {
+        // 1) retry gaps/timeouts
         match self.evaluate_retry() {
             RetryLearnResult::NoGap => {
                 // nothing to do
             }
-
             RetryLearnResult::Skip(slot) => {
                 logger::log_debug(&format!("[Learner Agent] Skipping retry for slot {}", slot));
             }
-
-            //* Assume event driven here */
             RetryLearnResult::Retry(slot) => {
                 let retry_msg = NetworkMessage {
                     sender: self.node.clone(),
@@ -196,7 +301,6 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
                     "[Learner Agent] Broadcasting RETRY LEARN for slot {}",
                     slot
                 ));
-
                 if self.config.acceptors_send_learns {
                     network::send_message_forget(&self.acceptors, &retry_msg);
                 } else {
@@ -204,6 +308,26 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
                 }
             }
         }
+
+        // 2) maybe execute & collect, but only every exec_interval_ms
+        let now = Instant::now();
+        let elapsed = now.duration_since(*self.last_exec_time.borrow());
+        let interval = Duration::from_millis(self.config.exec_interval_ms);
+
+        if elapsed < interval {
+            // too soon, skip this tick
+            logger::log_debug(&format!(
+                "[Learner Agent] Skipping execute (only {:.0}ms since last; need {}ms)",
+                elapsed.as_millis(),
+                self.config.exec_interval_ms
+            ));
+            return;
+        }
+
+        // 3) it’s time! update timestamp and do the work
+        self.last_exec_time.replace(now);
+        let exec = self.execute_and_collect(Some(self.config.executed_batch_size));
+        let _ = self.dispatch_executed(exec);
     }
 
     fn handle_message(&self, message: NetworkMessage) -> NetworkMessage {
@@ -217,27 +341,10 @@ impl GuestLearnerAgentResource for MyLearnerAgentResource {
                 let executed =
                     self.learn_and_execute(payload.slot, payload.value.clone(), message.sender);
 
-                if executed.results.is_empty() || !self.config.learners_send_executed {
-                    return NetworkMessage {
-                        sender: self.node.clone(),
-                        payload: MessagePayload::Ignore,
-                    };
-                }
-
-                let exec_msg = NetworkMessage {
+                self.dispatch_executed(executed).unwrap_or(NetworkMessage {
                     sender: self.node.clone(),
-                    payload: MessagePayload::Executed(executed),
-                };
-
-                if self.config.is_event_driven {
-                    network::send_message_forget(&self.proposers, &exec_msg);
-                    NetworkMessage {
-                        sender: self.node.clone(),
-                        payload: MessagePayload::Ignore,
-                    }
-                } else {
-                    exec_msg
-                }
+                    payload: MessagePayload::Ignore,
+                })
             }
 
             other_message => {

--- a/paxos-wasm/core/learner/src/learner.rs
+++ b/paxos-wasm/core/learner/src/learner.rs
@@ -1,21 +1,21 @@
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap};
-use std::time::{Duration, Instant};
 
 mod bindings {
     wit_bindgen::generate!({
         path: "../../shared/wit",
         world: "learner-world",
-    additional_derives: [PartialEq],
+    additional_derives: [PartialEq, Clone, Eq, Hash],
     });
 }
 
 bindings::export!(MyLearner with_types_in bindings);
 
-use bindings::paxos::default::paxos_types::{Accepted, Learn, Node, Slot, Value};
+use bindings::paxos::default::learner_types::LearnResult;
+use bindings::paxos::default::paxos_types::{Learn, Node, Slot, Value};
 
 use bindings::exports::paxos::default::learner::{
-    Guest, GuestLearnerResource, LearnResult, LearnedEntry, LearnerState,
+    Guest, GuestLearnerResource, LearnedEntry, LearnerState,
 };
 use bindings::paxos::default::logger;
 
@@ -26,207 +26,156 @@ impl Guest for MyLearner {
 }
 
 struct MyLearnerResource {
-    learned: RefCell<BTreeMap<Slot, Value>>,
-    next_to_execute: Cell<Slot>,
-    execution_log: RefCell<BTreeMap<Slot, Value>>,
-    max_gap_size: u64,
     num_acceptors: u64,
 
-    slot_learns: RefCell<BTreeMap<Slot, HashMap<u64, Learn>>>, // TODO: new, needed?
-    flush_timeout: Duration,
-    last_flush: Cell<Instant>, // TODO: move to agent
-
-    retry_timeout: Duration, // TODO: move to agent
-    last_message_time: Cell<Instant>,
+    slot_learns: RefCell<BTreeMap<Slot, HashMap<u64, Learn>>>,
+    learned: RefCell<BTreeMap<Slot, Value>>,
+    executed: RefCell<BTreeMap<Slot, Value>>,
+    adu: Cell<Slot>,
 }
 
 impl MyLearnerResource {
     fn quorum(&self) -> usize {
         return ((self.num_acceptors / 2) + 1) as usize;
     }
+
+    /// Gather learns for `slot`, see if any value hits quorum.
+    /// If so, returns `Some(value)`; otherwise `None`.
+    fn check_quorum(&self, slot: Slot) -> Option<Value> {
+        let binding = self.slot_learns.borrow();
+        let slot_map = match binding.get(&slot) {
+            Some(m) if m.len() >= self.quorum() => m,
+            _ => return None,
+        };
+
+        // Count frequencies
+        let mut counts: HashMap<&Value, usize> = HashMap::new();
+        for learn in slot_map.values() {
+            *counts.entry(&learn.value).or_default() += 1;
+        }
+        // Find any value with >= quorum
+        counts
+            .into_iter()
+            .find(|(_, cnt)| *cnt >= self.quorum())
+            .map(|(val, _)| val.clone())
+    }
 }
 
 impl GuestLearnerResource for MyLearnerResource {
-    /// Constructor: Initialize an empty BTreeMap.
     fn new(num_acceptors: u64) -> Self {
         Self {
-            learned: RefCell::new(BTreeMap::new()),
-            next_to_execute: Cell::new(1),
-            execution_log: RefCell::new(BTreeMap::new()),
-            max_gap_size: 10,
             num_acceptors,
-
             slot_learns: RefCell::new(BTreeMap::new()),
-            flush_timeout: Duration::from_millis(10),
-            last_flush: Cell::new(Instant::now()),
-
-            retry_timeout: Duration::from_millis(500),
-            last_message_time: Cell::new(Instant::now()),
+            learned: RefCell::new(BTreeMap::new()),
+            executed: RefCell::new(BTreeMap::new()),
+            adu: Cell::new(0),
         }
     }
 
     fn get_state(&self) -> LearnerState {
-        let learned_list: Vec<LearnedEntry> = self
-            .execution_log
+        let list = self
+            .learned
             .borrow()
             .iter()
-            .map(|(&slot, value)| LearnedEntry {
+            .map(|(&slot, v)| LearnedEntry {
                 slot,
-                value: value.clone(),
+                value: v.clone(),
             })
             .collect();
-        LearnerState {
-            learned: learned_list,
-        }
+        LearnerState { learned: list }
     }
 
-    fn get_next_to_execute(&self) -> Slot {
-        self.next_to_execute.get()
+    fn get_adu(&self) -> Slot {
+        self.adu.get()
     }
 
-    /// Record that a value has been learned for a given slot.
-    /// If the slot already has a learned value, a warning is logged and the new value is ignored.
-    /// Can only execute consecutive slots starting from the next_to_execute slot.
-    fn learn(&self, slot: Slot, value: Value) -> LearnResult {
+    fn get_highest_learned(&self) -> Slot {
+        self.learned
+            .borrow()
+            .keys()
+            .last()
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Try to record a learned value.  
+    /// Returns `true` if we actually inserted, `false` if we already had it.
+    fn learn(&self, slot: Slot, value: Value) -> bool {
         let mut learned_map = self.learned.borrow_mut();
-        let execution_log = self.execution_log.borrow_mut();
+        let exec_log = self.executed.borrow();
 
-        // Insert learn if have not learned yet
-        if !learned_map.contains_key(&slot) && !execution_log.contains_key(&slot) {
-            logger::log_info(&format!(
-                "[Core Learner]: For slot {}, learned value {:?}",
+        if learned_map.contains_key(&slot) || exec_log.contains_key(&slot) {
+            logger::log_debug(&format!(
+                "[Core Learner]: Slot {} already learned, ignoring {:?}",
                 slot, value
             ));
-            learned_map.insert(slot, value);
+            false
         } else {
-            logger::log_warn(&format!(
-                "Learner: Slot {} already has a learned value. Ignoring new value {:?}.",
-                slot, value
-            ));
-        }
-        return LearnResult::Ignore;
-    }
-
-    // TODO
-
-    // Handles incoming learns from acceptors. Checks for quorum and and stores the learned value. Returns ready to be executed slots if any.
-    fn handle_learn(&self, learn: Learn, from: Node) -> LearnResult {
-        let now = Instant::now();
-        self.last_message_time.set(now);
-        let execution_log = self.execution_log.borrow();
-        if !execution_log.contains_key(&learn.slot) {
             logger::log_info(&format!(
-                "[Core Learner]: Received learn for slot {} from node {}",
-                learn.slot, from.node_id
+                "[Core Learner] Recording learned value {:?} for slot {}",
+                value, slot
             ));
-            let slot = learn.slot;
-            self.slot_learns
-                .borrow_mut()
-                .entry(slot)
-                .or_insert_with(HashMap::new)
-                .insert(from.node_id, learn.clone());
-
-            if let Some(sender_map) = self.slot_learns.borrow().get(&slot) {
-                if sender_map.len() >= self.quorum() {
-                    let learns: Vec<&Learn> = sender_map.values().collect();
-
-                    for &candidate in &learns {
-                        let count = learns.iter().filter(|&&learn| learn == candidate).count();
-
-                        if count >= self.quorum() {
-                            logger::log_info(&format!(
-                                "[Core Learner]: Learned full Learn {:?} for slot {} with count {}",
-                                candidate, slot, count
-                            ));
-                            // Learn: candidate.value or the full candidate
-                            self.learned
-                                .borrow_mut()
-                                .insert(slot, candidate.value.clone());
-                            break;
-                        }
-                    }
-                }
-            }
+            learned_map.insert(slot, value.clone());
+            true
         }
-        return LearnResult::Ignore;
     }
 
-    // TODO
+    // Handles incoming learns from acceptors. Checks for quorum and and potentially stores the learned value.
+    fn handle_learn(&self, learn: Learn, sender: Node) -> bool {
+        // track the incoming Learn
+        let slot = learn.slot;
+        self.slot_learns
+            .borrow_mut()
+            .entry(slot)
+            .or_default()
+            .insert(sender.node_id, learn.clone());
 
+        logger::log_info(&format!(
+            "[Core Learner] Recorded vote for slot {}: current value {:?} (awaiting quorum).",
+            slot, learn.value
+        ));
+
+        // now see if quorum is reached
+        if let Some(quorum_value) = self.check_quorum(slot) {
+            self.learn(slot, quorum_value)
+        } else {
+            false
+        }
+    }
+
+    /// Try to pop up to `max_batch` learned entries, in slot order, starting from adu + 1
     fn to_be_executed(&self) -> LearnResult {
-        let mut learned_map = self.learned.borrow_mut();
-        let mut next_to_execute = self.get_next_to_execute();
+        let mut out = Vec::new();
+        let mut learned = self.learned.borrow_mut();
+        let mut executed = self.executed.borrow_mut();
+        let mut slot = self.adu.get() + 1;
 
-        let mut contiguous_ready = 0;
-        let mut probe_slot = next_to_execute;
-
-        // First just *count* how many contiguous slots are ready
-        while learned_map.contains_key(&probe_slot) {
-            contiguous_ready += 1;
-            probe_slot += 1;
-
-            if contiguous_ready >= 10 {
-                // Tcp socket problems if message is to big. Also noticed increadbly slowdowns when sending 20+ slots
-                break;
-            }
+        // Pop all contiguous slots
+        while let Some(val) = learned.remove(&slot) {
+            executed.insert(slot, val.clone());
+            out.push(LearnedEntry { slot, value: val });
+            slot += 1;
         }
 
-        // Ensure 10 is sent at the sime time - boost throughput by 50ops/s ca. Need to itroduce some mechanism here to ensure that
-        // if we do not have 10 slots ready based on some timeout we need to send the slots we have
-        // or else the system will be stuck wating for more slots to be learned.
-        // This is fine when we are testing with with request_size % 10 = 0
-        if contiguous_ready >= 10 {
-            let mut to_be_executed = Vec::new();
-            let mut execution_log = self.execution_log.borrow_mut();
-
-            // Now actually remove and execute them
-            for _ in 0..contiguous_ready {
-                if let Some(val) = learned_map.remove(&next_to_execute) {
-                    execution_log.insert(next_to_execute, val.clone());
-                    to_be_executed.push(LearnedEntry {
-                        slot: next_to_execute,
-                        value: val,
-                    });
-                    next_to_execute += 1;
-                    self.next_to_execute.set(next_to_execute);
-                }
-            }
-
-            return LearnResult::Execute(to_be_executed);
-        } else {
-            LearnResult::Ignore
-        }
-        // Check if some learns are ready to
-    }
-
-    // Checker for gaps in the learned slots. Should be called at reasoinable a interval.
-    fn check_for_gap(&self) -> Option<Slot> {
-        let learned_map = self.learned.borrow_mut();
-        let next_to_execute = self.next_to_execute.get();
-        let max_learned_slot = learned_map.keys().max().copied().unwrap_or(0);
-
-        // If no slot beyond next_to_execute has been learned, nothing to gap.
-        if max_learned_slot <= next_to_execute {
-            return None;
+        // If nothing was ready, return
+        if out.is_empty() {
+            return LearnResult::Ignore;
         }
 
-        // If the next slot is already learned, there is no gap.
-        if learned_map.contains_key(&next_to_execute) {
-            return None;
-        }
+        // Advance our cursor
+        let new_adu = slot.saturating_sub(1); // TODO: Lol
+        self.adu.set(new_adu);
 
-        // Compute the gap between the maximum learned slot and the next expected one.
-        let gap = max_learned_slot - next_to_execute;
-
-        let now = Instant::now();
-        // return if gap is > max_gap_size or if the time since last message is > retry_timeout
-        if gap >= self.max_gap_size
-            || (gap > 0 && now.duration_since(self.last_message_time.get()) > self.retry_timeout)
-        {
-            Some(next_to_execute)
-        } else {
-            None
-        }
+        let first = out.first().unwrap().slot;
+        let last = out.last().unwrap().slot;
+        logger::log_info(&format!(
+            "[Core Learner] executing slots {}..{} ({} entries), with new adu: {}",
+            first,
+            last,
+            out.len(),
+            new_adu,
+        ));
+        LearnResult::Execute(out)
     }
 
     /// Returns the learned entry for a specific slot, if it exists.

--- a/paxos-wasm/modular-ws/src/config.rs
+++ b/paxos-wasm/modular-ws/src/config.rs
@@ -2,6 +2,7 @@ use std::{fs, path::Path};
 use yaml_rust::YamlLoader;
 
 use crate::bindings::paxos::default::{
+    logger::Level,
     network_types::PaxosRole,
     paxos_types::{Node, RunConfig},
 };
@@ -11,6 +12,7 @@ pub struct Config {
     pub remote_nodes: Vec<Node>,
     pub is_leader: bool,
     pub run_config: RunConfig,
+    pub log_level: Level,
 }
 
 impl Config {
@@ -20,6 +22,16 @@ impl Config {
         let doc = &docs[0];
 
         let raw = doc["nodes"].as_vec().unwrap();
+
+        // Get the log level
+        let level_str = doc["log_level"].as_str().unwrap_or("info").to_lowercase();
+        let log_level = match level_str.as_str() {
+            "debug" => Level::Debug,
+            "info" => Level::Info,
+            "warning" => Level::Warn,
+            "error" => Level::Error,
+            other => panic!("unknown log_level `{}`", other),
+        };
 
         // Build all nodes
         let nodes: Vec<Node> = raw
@@ -76,6 +88,7 @@ impl Config {
             remote_nodes,
             is_leader,
             run_config,
+            log_level,
         }
     }
 }

--- a/paxos-wasm/modular-ws/src/config.rs
+++ b/paxos-wasm/modular-ws/src/config.rs
@@ -62,7 +62,12 @@ impl Config {
             learners_send_executed: r["learners_send_executed"].as_bool().unwrap(),
             prepare_timeout: r["prepare_timeout"].as_i64().unwrap() as u64,
             demo_client: r["demo_client"].as_bool().unwrap(),
+            batch_size: r["batch_size"].as_i64().unwrap() as u64,
             tick_ms: r["tick_ms"].as_i64().unwrap() as u64,
+            exec_interval_ms: r["exec_interval_ms"].as_i64().unwrap() as u64,
+            retry_interval_ms: r["retry_interval_ms"].as_i64().unwrap() as u64,
+            learn_max_gap: r["learn_max_gap"].as_i64().unwrap() as u64,
+            executed_batch_size: r["executed_batch_size"].as_i64().unwrap() as u64,
             client_server_port: r["client_server_port"].as_i64().unwrap() as u16,
         };
 

--- a/paxos-wasm/modular-ws/src/config.yaml
+++ b/paxos-wasm/modular-ws/src/config.yaml
@@ -28,9 +28,13 @@ nodes:
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
   is_event_driven: true
-  acceptors_send_learns: false
+  acceptors_send_learns: true
   learners_send_executed: true
   prepare_timeout: 1000
   demo_client: false
+  batch_size: 10
   tick_ms: 10
-  client_server_port: 50057
+  exec_interval_ms: 500
+  retry_interval_ms: 1000
+  learn_max_gap: 10
+  client_server_port: 60000

--- a/paxos-wasm/modular-ws/src/config.yaml
+++ b/paxos-wasm/modular-ws/src/config.yaml
@@ -1,5 +1,5 @@
 # ─── global cluster settings ───────────────────────────
-leader_id: 1
+log_level: info # "debug", "info", "warning", "error"
 
 # full list of nodes and which paxos-role they have
 nodes:
@@ -33,8 +33,9 @@ run_config:
   prepare_timeout: 1000
   demo_client: false
   batch_size: 10
-  tick_ms: 10
-  exec_interval_ms: 500
-  retry_interval_ms: 1000
+  tick_ms: 5
+  exec_interval_ms: 100
+  retry_interval_ms: 500
   learn_max_gap: 10
+  executed_batch_size: 10
   client_server_port: 60000

--- a/paxos-wasm/modular-ws/src/host_logger.rs
+++ b/paxos-wasm/modular-ws/src/host_logger.rs
@@ -10,8 +10,14 @@ use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::bindings::paxos::default::logger::Level;
 
-pub(crate) fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+pub(crate) fn init_tracing_with(level: Level) {
+    let level_str = match level {
+        Level::Debug => "debug",
+        Level::Info => "info",
+        Level::Warn => "warn",
+        Level::Error => "error",
+    };
+    let filter = EnvFilter::new(level_str);
     let subscriber = fmt().with_env_filter(filter).finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global tracing subscriber");

--- a/paxos-wasm/modular-ws/src/main.rs
+++ b/paxos-wasm/modular-ws/src/main.rs
@@ -19,7 +19,6 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    host_logger::init_tracing();
     let args = Args::parse();
 
     let cfg = Config::load(&args.config, args.node_id);
@@ -27,6 +26,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Node {} @{} role={:?} is_leader={}",
         cfg.node.node_id, cfg.node.address, cfg.node.role, cfg.is_leader,
     );
+
+    host_logger::init_tracing_with(cfg.log_level);
 
     let paxos = PaxosWasmtime::new(
         cfg.node.clone(),

--- a/paxos-wasm/network-ws/client_server/src/client_server_tcp.rs
+++ b/paxos-wasm/network-ws/client_server/src/client_server_tcp.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 
-use wasi::io::streams::StreamError;
 use wasi::sockets::instance_network::instance_network;
 use wasi::sockets::network::{IpAddressFamily, IpSocketAddress, Ipv4SocketAddress};
 use wasi::sockets::tcp::{ErrorCode as TcpErrorCode, InputStream, OutputStream, TcpSocket};

--- a/paxos-wasm/runner-ws/src/config.rs
+++ b/paxos-wasm/runner-ws/src/config.rs
@@ -2,6 +2,7 @@ use std::{fs, path::Path};
 use yaml_rust::YamlLoader;
 
 use crate::bindings::paxos::default::{
+    logger::Level,
     network_types::PaxosRole,
     paxos_types::{Node, RunConfig},
 };
@@ -11,6 +12,7 @@ pub struct Config {
     pub remote_nodes: Vec<Node>,
     pub is_leader: bool,
     pub run_config: RunConfig,
+    pub log_level: Level,
 }
 
 impl Config {
@@ -20,6 +22,16 @@ impl Config {
         let doc = &docs[0];
 
         let raw = doc["nodes"].as_vec().unwrap();
+
+        // Get the log level
+        let level_str = doc["log_level"].as_str().unwrap_or("info").to_lowercase();
+        let log_level = match level_str.as_str() {
+            "debug" => Level::Debug,
+            "info" => Level::Info,
+            "warning" => Level::Warn,
+            "error" => Level::Error,
+            other => panic!("unknown log_level `{}`", other),
+        };
 
         // Build all nodes
         let nodes: Vec<Node> = raw
@@ -76,6 +88,7 @@ impl Config {
             remote_nodes,
             is_leader,
             run_config,
+            log_level,
         }
     }
 }

--- a/paxos-wasm/runner-ws/src/config.rs
+++ b/paxos-wasm/runner-ws/src/config.rs
@@ -62,7 +62,12 @@ impl Config {
             learners_send_executed: r["learners_send_executed"].as_bool().unwrap(),
             prepare_timeout: r["prepare_timeout"].as_i64().unwrap() as u64,
             demo_client: r["demo_client"].as_bool().unwrap(),
+            batch_size: r["batch_size"].as_i64().unwrap() as u64,
             tick_ms: r["tick_ms"].as_i64().unwrap() as u64,
+            exec_interval_ms: r["exec_interval_ms"].as_i64().unwrap() as u64,
+            retry_interval_ms: r["retry_interval_ms"].as_i64().unwrap() as u64,
+            learn_max_gap: r["learn_max_gap"].as_i64().unwrap() as u64,
+            executed_batch_size: r["executed_batch_size"].as_i64().unwrap() as u64,
             client_server_port: r["client_server_port"].as_i64().unwrap() as u16,
         };
 

--- a/paxos-wasm/runner-ws/src/config.yaml
+++ b/paxos-wasm/runner-ws/src/config.yaml
@@ -1,6 +1,5 @@
-# ─── global cluster settings ───────────────────────────
-leader_id: 1
-log_level: warning
+# ─── Local Paxos Cluster ───────────────────────────
+log_level: info # "debug", "info", "warning", "error"
 
 # full list of nodes and which paxos-role they have
 nodes:
@@ -24,13 +23,13 @@ nodes:
     role: "proposer"
   - node_id: 7
     address: "127.0.0.1:50057"
-    role: "coordinator" # Last node has to be either "proposer" or "coordinator"
+    role: "proposer" # Last node has to be either "proposer" or "coordinator"
 
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
   is_event_driven: true
   acceptors_send_learns: true
-  learners_send_executed: false
+  learners_send_executed: true
   prepare_timeout: 1000
   demo_client: false
   batch_size: 10

--- a/paxos-wasm/runner-ws/src/config.yaml
+++ b/paxos-wasm/runner-ws/src/config.yaml
@@ -1,5 +1,6 @@
 # ─── global cluster settings ───────────────────────────
 leader_id: 1
+log_level: warning
 
 # full list of nodes and which paxos-role they have
 nodes:
@@ -23,14 +24,19 @@ nodes:
     role: "proposer"
   - node_id: 7
     address: "127.0.0.1:50057"
-    role: "proposer" # Last node has to be either "proposer" or "coordinator"
+    role: "coordinator" # Last node has to be either "proposer" or "coordinator"
 
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
   is_event_driven: true
   acceptors_send_learns: true
-  learners_send_executed: true
+  learners_send_executed: false
   prepare_timeout: 1000
   demo_client: false
-  tick_ms: 10
+  batch_size: 10
+  tick_ms: 5
+  exec_interval_ms: 100
+  retry_interval_ms: 500
+  learn_max_gap: 10
+  executed_batch_size: 10
   client_server_port: 60000

--- a/paxos-wasm/runner-ws/src/host_logger.rs
+++ b/paxos-wasm/runner-ws/src/host_logger.rs
@@ -10,8 +10,14 @@ use tracing_subscriber::{EnvFilter, fmt};
 
 use crate::bindings::paxos::default::logger::Level;
 
-pub(crate) fn init_tracing() {
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+pub(crate) fn init_tracing_with(level: Level) {
+    let level_str = match level {
+        Level::Debug => "debug",
+        Level::Info => "info",
+        Level::Warn => "warn",
+        Level::Error => "error",
+    };
+    let filter = EnvFilter::new(level_str);
     let subscriber = fmt().with_env_filter(filter).finish();
     tracing::subscriber::set_global_default(subscriber)
         .expect("Failed to set global tracing subscriber");

--- a/paxos-wasm/runner-ws/src/main.rs
+++ b/paxos-wasm/runner-ws/src/main.rs
@@ -19,7 +19,6 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    host_logger::init_tracing();
     let args = Args::parse();
 
     let cfg = Config::load(&args.config, args.node_id);
@@ -27,6 +26,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "Node {} @{} role={:?} is_leader={}",
         cfg.node.node_id, cfg.node.address, cfg.node.role, cfg.is_leader,
     );
+
+    host_logger::init_tracing_with(cfg.log_level);
 
     let paxos = PaxosWasmtime::new(
         cfg.node.clone(),

--- a/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
+++ b/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
@@ -175,7 +175,7 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
     /// The coordinator queries its local acceptor for a promise and passes it along.
     fn prepare_phase(&self) -> PrepareResult {
         // Starts from 1, or the adu on the learner, the highest slot the learner has chosen.
-        let slot = self.learner_agent.get_adu();
+        let slot = self.learner_agent.get_adu() + 1;
         let ballot = self.proposer_agent.get_current_ballot();
 
         // Query local acceptor.

--- a/paxos-wasm/runners/runner/src/runner.rs
+++ b/paxos-wasm/runners/runner/src/runner.rs
@@ -31,27 +31,55 @@ struct DemoClientHelper {
 }
 
 struct MetricsHelper {
+    // short‐term batch stats
     stats_batch: usize,
     batch_count: Cell<usize>,
     batch_start: RefCell<Instant>,
+
+    // global stats (never reset until final)
+    global_count: Cell<usize>,
+    global_start: RefCell<Option<Instant>>,
+
+    // for “only once” final print
+    last_response: RefCell<Instant>,
+    idle_logged: AtomicBool,
 }
 
 impl MetricsHelper {
     fn track(&self, num_responses: usize) {
-        let new_total = self.batch_count.get() + num_responses;
-        self.batch_count.set(new_total);
+        // update both counters
+        let short = self.batch_count.get() + num_responses;
+        self.batch_count.set(short);
 
-        if new_total >= self.stats_batch {
+        let total = self.global_count.get() + num_responses;
+        self.global_count.set(total);
+
+        // mid‐run batch logging
+        if short >= self.stats_batch {
             let elapsed = self.batch_start.borrow().elapsed();
-            let throughput = new_total as f64 / elapsed.as_secs_f64();
-
-            logger::log_info(&format!(
-                "[Runner] last {} responses in {:?} → {:.2} rsp/sec",
-                new_total, elapsed, throughput
+            let th = short as f64 / elapsed.as_secs_f64();
+            logger::log_error(&format!(
+                "[Runner] Throughput: last {} responses in {:?} → {:.2} rsp/sec",
+                short, elapsed, th
             ));
-
+            // reset only the *batch* stats
             self.batch_count.set(0);
             *self.batch_start.borrow_mut() = Instant::now();
+        }
+    }
+
+    /// Print a final, one‐time throughput using the global counters.
+    fn flush_global(&self) {
+        if let Some(start) = *self.global_start.borrow() {
+            let total = self.global_count.get();
+            if total > 0 {
+                let elapsed = start.elapsed();
+                let th = total as f64 / elapsed.as_secs_f64();
+                logger::log_error(&format!(
+                    "[Runner] FINAL THROUGHPUT: {} responses over {:?} → {:.2} rsp/sec",
+                    total, elapsed, th
+                ));
+            }
         }
     }
 }
@@ -81,7 +109,16 @@ impl MyRunnerResource {
         if !self.paxos.is_leader() {
             return;
         }
-        for req in self.client_svr.get_requests() {
+        // peek at any incoming requests
+        let requests = self.client_svr.get_requests();
+        if !requests.is_empty() {
+            if self.metrics.global_start.borrow().is_none() {
+                *self.metrics.global_start.borrow_mut() = Some(Instant::now());
+                logger::log_info("[Runner] Starting global throughput timer");
+            }
+        }
+
+        for req in requests {
             self.paxos.submit_client_request(&req);
         }
     }
@@ -92,7 +129,7 @@ impl MyRunnerResource {
         }
     }
 
-    fn tick_paxos(&self) -> Option<Vec<ClientResponse>> {
+    fn run_paxos_loop(&self) -> Option<Vec<ClientResponse>> {
         // self.paxos.failure_service(); // TODO
 
         self.paxos.run_paxos_loop()
@@ -110,6 +147,10 @@ impl MyRunnerResource {
         self.client_svr.send_responses(&self.node, &responses);
 
         self.metrics.track(responses.len());
+
+        // mark that we just had activity
+        *self.metrics.last_response.borrow_mut() = Instant::now();
+        self.metrics.idle_logged.store(false, Ordering::Relaxed);
     }
 
     fn demo_client_work(&self, tick_ms: u64) {
@@ -167,11 +208,13 @@ impl GuestRunnerResource for MyRunnerResource {
 
         sleep(Duration::from_millis(1000)); // To allow all nodes to initialize
 
+        let now = Instant::now();
+
         let demo_client = if config.demo_client {
             Some(DemoClientHelper {
                 client_id: format!("client-{}", node.node_id),
                 client_seq: Cell::new(0),
-                last_request: RefCell::new(Instant::now()),
+                last_request: RefCell::new(now),
                 next_interval: Cell::new(Duration::from_millis(5)),
             })
         } else {
@@ -181,7 +224,11 @@ impl GuestRunnerResource for MyRunnerResource {
         let metrics = MetricsHelper {
             stats_batch: 100,
             batch_count: Cell::new(0),
-            batch_start: RefCell::new(Instant::now()),
+            batch_start: RefCell::new(now),
+            global_count: Cell::new(0),
+            global_start: RefCell::new(None),
+            last_response: RefCell::new(now),
+            idle_logged: AtomicBool::new(false),
         };
 
         Self {
@@ -197,7 +244,7 @@ impl GuestRunnerResource for MyRunnerResource {
     }
 
     fn run(&self) {
-        let tick_ms = 5; // TODO: Add this to RunConfig
+        let tick_ms = self.config.tick_ms;
         let tick_duration = Duration::from_millis(tick_ms);
         let mut next_tick = Instant::now() + tick_duration;
 
@@ -209,10 +256,17 @@ impl GuestRunnerResource for MyRunnerResource {
             if now >= next_tick {
                 self.demo_client_work(tick_ms);
 
-                if let Some(responses) = self.tick_paxos() {
+                if let Some(responses) = self.run_paxos_loop() {
                     self.dispatch_responses(responses);
                 }
                 next_tick += tick_duration;
+            }
+
+            // **Idle‐timeout check**: 1 s since last_response, print final throughput once
+            let idle = now.duration_since(*self.metrics.last_response.borrow());
+            if idle >= Duration::from_secs(1) && !self.metrics.idle_logged.load(Ordering::Relaxed) {
+                self.metrics.flush_global();
+                self.metrics.idle_logged.store(true, Ordering::Relaxed);
             }
 
             // sleep "only" until our next tick

--- a/paxos-wasm/shared/config/config_examples/example.config.local.yaml
+++ b/paxos-wasm/shared/config/config_examples/example.config.local.yaml
@@ -1,6 +1,5 @@
 # ─── Local Paxos Cluster ───────────────────────────
-
-leader_id: 1
+log_level: info # "debug", "info", "warning", "error"
 
 # full list of nodes and which paxos-role they have
 nodes:
@@ -32,9 +31,14 @@ nodes:
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
   is_event_driven: true
-  acceptors_send_learns: false
+  acceptors_send_learns: true
   learners_send_executed: true
   prepare_timeout: 1000
   demo_client: false
-  tick_ms: 10
+  batch_size: 10
+  tick_ms: 5
+  exec_interval_ms: 100
+  retry_interval_ms: 500
+  learn_max_gap: 10
+  executed_batch_size: 10
   client_server_port: 60000

--- a/paxos-wasm/shared/config/config_examples/example.config.prod.yaml
+++ b/paxos-wasm/shared/config/config_examples/example.config.prod.yaml
@@ -1,6 +1,5 @@
 # ─── Production Paxos Cluster ───────────────────────────
-
-leader_id: 1
+log_level: warning # "debug", "info", "warning", "error"
 
 # full list of nodes and which paxos-role they have
 nodes:
@@ -32,9 +31,14 @@ nodes:
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
   is_event_driven: true
-  acceptors_send_learns: false
+  acceptors_send_learns: true
   learners_send_executed: true
   prepare_timeout: 1000
   demo_client: false
-  tick_ms: 10
+  batch_size: 10
+  tick_ms: 5
+  exec_interval_ms: 100
+  retry_interval_ms: 500
+  learn_max_gap: 10
+  executed_batch_size: 10
   client_server_port: 60000

--- a/paxos-wasm/shared/config/config_examples/example.run-demo-client.sh
+++ b/paxos-wasm/shared/config/config_examples/example.run-demo-client.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # ─── Tunables ────────────────────────────────────────────
 NUM_CLIENTS=10
-NUM_REQUESTS=1000
+NUM_REQUESTS=100
 MODE="persistent" # "oneshot" or "persistent"
 LEADER="127.0.0.1:60000"
 TIMEOUT_SECS=20 # used only by client logic now

--- a/paxos-wasm/shared/config/config_examples/example_config.rs
+++ b/paxos-wasm/shared/config/config_examples/example_config.rs
@@ -2,15 +2,18 @@ use std::{fs, path::Path};
 use yaml_rust::YamlLoader;
 
 use crate::bindings::paxos::default::{
+    logger::Level,
     network_types::PaxosRole,
     paxos_types::{Node, RunConfig},
 };
+
 //* Example config that needs to be copy pasted due to the bindings used. */
 pub struct Config {
     pub node: Node,
     pub remote_nodes: Vec<Node>,
     pub is_leader: bool,
     pub run_config: RunConfig,
+    pub log_level: Level,
 }
 
 impl Config {
@@ -20,6 +23,16 @@ impl Config {
         let doc = &docs[0];
 
         let raw = doc["nodes"].as_vec().unwrap();
+
+        // Get the log level
+        let level_str = doc["log_level"].as_str().unwrap_or("info").to_lowercase();
+        let log_level = match level_str.as_str() {
+            "debug" => Level::Debug,
+            "info" => Level::Info,
+            "warning" => Level::Warn,
+            "error" => Level::Error,
+            other => panic!("unknown log_level `{}`", other),
+        };
 
         // Build all nodes
         let nodes: Vec<Node> = raw
@@ -62,7 +75,12 @@ impl Config {
             learners_send_executed: r["learners_send_executed"].as_bool().unwrap(),
             prepare_timeout: r["prepare_timeout"].as_i64().unwrap() as u64,
             demo_client: r["demo_client"].as_bool().unwrap(),
+            batch_size: r["batch_size"].as_i64().unwrap() as u64,
             tick_ms: r["tick_ms"].as_i64().unwrap() as u64,
+            exec_interval_ms: r["exec_interval_ms"].as_i64().unwrap() as u64,
+            retry_interval_ms: r["retry_interval_ms"].as_i64().unwrap() as u64,
+            learn_max_gap: r["learn_max_gap"].as_i64().unwrap() as u64,
+            executed_batch_size: r["executed_batch_size"].as_i64().unwrap() as u64,
             client_server_port: r["client_server_port"].as_i64().unwrap() as u16,
         };
 
@@ -71,6 +89,7 @@ impl Config {
             remote_nodes,
             is_leader,
             run_config,
+            log_level,
         }
     }
 }

--- a/paxos-wasm/shared/wit/agents.wit
+++ b/paxos-wasm/shared/wit/agents.wit
@@ -95,7 +95,7 @@ interface acceptor-agent {
 
         handle-message: func(message: network-message) -> network-message;
     
-        retry-learn: func(slot: slot, sender: node);
+        retry-learn: func(slot: slot);
     }
 }
 
@@ -110,10 +110,13 @@ interface learner-agent {
         /// Returns a snapshot of the full Paxos state (e.g. learned entries, kv-store state).
         get-state: func() -> tuple<learner-state, list<kv-pair>>;
 
-        get-next-to-execute : func() -> slot;
+        /// The highest learned slot.
+        get-adu: func() -> slot;
 
         /// Learn the new value, and return a list of executed values and adu.
         learn-and-execute: func(slot: slot, value: value, sender: node) -> executed;  
+
+        execute-and-collect: func(max-batch: option<u64>) -> executed;
 
         evaluate-retry: func() -> retry-learn-result;
 

--- a/paxos-wasm/shared/wit/agents.wit
+++ b/paxos-wasm/shared/wit/agents.wit
@@ -113,11 +113,16 @@ interface learner-agent {
         /// The highest learned slot.
         get-adu: func() -> slot;
 
-        /// Learn the new value, and return a list of executed values and adu.
-        learn-and-execute: func(slot: slot, value: value, sender: node) -> executed;  
+        /// Records the learn, either with quorum check or not. Returns if learned.
+        record-learn: func(slot: slot, value: value, sender: node) -> bool;
 
-        execute-and-collect: func(max-batch: option<u64>) -> executed;
+        /// Pops chosen learns to be executed, and applies them to the state machine.
+        execute-chosen-learns: func();
 
+        /// Collects a batch of executed, either all up to max-batch, or wait for a full batch.
+        collect-executed: func(max-batch: option<u64>, require-full: bool) -> executed;
+
+        /// Evaluates if need to retry a slot, due to too large gap and retry interval.
         evaluate-retry: func() -> retry-learn-result;
 
         /// Processes incoming network messages (such as commit notifications and accepted responses).

--- a/paxos-wasm/shared/wit/core.wit
+++ b/paxos-wasm/shared/wit/core.wit
@@ -76,12 +76,12 @@ interface learner {
     resource learner-resource {
         constructor(num-acceptors: u64);
         get-state: func() -> learner-state;
-        learn: func(slot: slot, value: value) -> learn-result;
-        handle-learn: func(learn: learn, sender: node) -> learn-result;
-        get-learned: func(slot: slot) -> option<learned-entry>;
-        get-next-to-execute : func() -> slot;
-        check-for-gap: func() -> option<slot>;
+        learn: func(slot: slot, value: value) -> bool;
+        handle-learn: func(learn: learn, sender: node) -> bool;
         to-be-executed: func() -> learn-result;
+        get-highest-learned: func() -> slot;
+        get-adu: func() -> slot;
+        get-learned: func(slot: slot) -> option<learned-entry>;
     }
 }
 

--- a/paxos-wasm/shared/wit/types.wit
+++ b/paxos-wasm/shared/wit/types.wit
@@ -5,7 +5,12 @@ interface paxos-types {
         learners-send-executed: bool,   // Toggle if the learners should send the executed message to all proposers or not.
         prepare-timeout: u64,           // The timeout period before trying a new prepare-phase in ms e.g., 5000 for 5 seconds.
         demo-client: bool,              // Enables a simulated demo client by creating client requests at an interval in the respective server.
+        batch-size: u64,                // The number commonly used to perform certain actions N times before continuing.
         tick-ms: u64,                   // The tickrate in ms which is the minimum wait time in-between ticks and run_paxos_loop calls.
+        exec-interval-ms: u64,          // The timeout period for which the learner forcefully sends executed even though not having batch size to send.
+        retry-interval-ms: u64,         // The timeout period for which the learner issues a retry-learn message to either the acceptors or proposers.
+        learn-max-gap: u64,             // The maximum gap between missing learn and highest seen learn before issuing a retry.
+        executed-batch-size: u64,       // The maximum number of executed results to send in one Executed message. 
         client-server-port: u16         // The port the client connects to on the leaders address.
         // ... Add more?
     } 
@@ -53,7 +58,11 @@ interface paxos-types {
     }
 
     type cmd = option<operation>;
-    type cmd-result = option<kv-value>;
+
+    variant cmd-result{
+        no-op,
+        cmd-value(option<kv-value>),
+    }
 
     /// Represents the command or operation to be executed.
     record value {


### PR DESCRIPTION
    "Working" new learner and coordinator. Still need some cleanup and fine tuning. Some other changes too.

    - Acceptor agent retry learn broadcasts to all learners, since if one learner needs to retry, maybe more is missing?
    - Kv-store and learner now properly handles a no-op (missing operation) and returns a failure on that slot.
    - Proposer agent now handles success false from learner, returning that in the client response to client.
    - Proposer agent only re-enqueue a failed value if it is a valid value with an valid Operation due to no-op for its slot.
    - Added more flags to the config yaml, such as exec_interval_ms and executed_batch_size
    - Made the runner metrics collection work better, now showing a final throughput.
    - First attempt at optimizing and reworking the learner and learner agent, and making it work with coordinator.
    - Simplified state in Core learner, making the timing and retry decisions only be done by the learner agent.
    - Make the learner finalize a chosen learn as soon as possible, and have the learner agent care about the handling and the batching of the execution of those learns.
    - Make the learner agent have the responsibility of performing retry logic, both due to retry timeout and the maximum gap.
    - Decouple the execution of learns, and the collection of executed that the leader will process.
    - Allow to execute learns both when receiving learns and on an interval through the run paxos loop.
    - Make the coordinator perform non-leader learner logic in its run paxos loop.
    - Make the coordinator (almost) properly handle when the acceptors send learns.
    - Quickfixes
    
    
    Final fixes to the learner and coordinator

    - Fixed serializer for the new CmdResult type
    - Split the learner agent functions to learn, execute and collect executed more.
    - Fixed their usage at the coordinator.
    - Make the coordinator local acceptor also broadcast learn and have the local learner record its learn when acceptors send learn flag is true.
    
    
    Added back the ability to easily change the log level.
    
    