### PR TITLE
Add logic for testing wasm overhead using network component vs native…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,119 +2,72 @@
 resolver = "3"
 
 default-members = [
-    "paxos-rust",
-
-    "paxos-wasm/core",
-    "paxos-wasm/agents",
-    "paxos-wasm/runners",
-    # "paxos-wasm/composed-grpc",
-    # "paxos-wasm/modular-grpc",
-    "paxos-wasm/modular-ws",
-    "paxos-wasm/modular-ws-client",
-    "paxos-wasm/runner-ws",
+  "paxos-rust",
+  "paxos-wasm/core",
+  "paxos-wasm/agents",
+  "paxos-wasm/runners", # "paxos-wasm/composed-grpc",  # "paxos-wasm/modular-grpc",
+  "paxos-wasm/modular-ws",
+  "paxos-wasm/modular-ws-client",
+  "paxos-wasm/runner-ws",
+  "pocs/wasm-overhead/native",
 ]
 
 members = [
-    "paxos-rust",
-
-    # "paxos-wasm",
-
-    "paxos-wasm/core",
-    "paxos-wasm/core/proposer",
-    "paxos-wasm/core/acceptor",
-    "paxos-wasm/core/learner",
-    "paxos-wasm/core/kv-store",
-
-    "paxos-wasm/core/leader-detector",
-    "paxos-wasm/core/failure-detector",
-
-    "paxos-wasm/agents",
-    "paxos-wasm/agents/proposer-agent",
-    "paxos-wasm/agents/acceptor-agent",
-    "paxos-wasm/agents/learner-agent",
-    "paxos-wasm/agents/kv-store-agent",
-
-    "paxos-wasm/runners",
-    "paxos-wasm/runners/paxos-coordinator",
-    "paxos-wasm/runners/runner",
-
-    "paxos-wasm/composed-grpc",
-    "paxos-wasm/composed-grpc/client",
-    "paxos-wasm/composed-grpc/client-cli",
-    "paxos-wasm/composed-grpc/command",
-
-    "paxos-wasm/network-ws",
-    "paxos-wasm/network-ws/serializer",
-    "paxos-wasm/network-ws/network-server",
-    "paxos-wasm/network-ws/client-server",
-    "paxos-wasm/network-ws/tcp-client",
-    # "paxos-wasm/network-ws/udp-client",
-
-    "paxos-wasm/runner-ws",
-
-    # TODO: Enable when fixed
-    # "paxos-wasm/modular-grpc",
-    # "paxos-wasm/modular-grpc/client",
-
-    "paxos-wasm/modular-ws",
-    "paxos-wasm/modular-ws/client",
-    "paxos-wasm/modular-ws/tcp-server",
-    # "paxos-wasm/modular-ws/udp-server",
-
-    "paxos-wasm/modular-ws-client",
-    "paxos-wasm/modular-ws-client/paxos-ws-client",
-
-    "paxos-wasm/shared/utils",
-    "paxos-wasm/shared/grpc",
-    "paxos-wasm/shared/proto",
-
-    "pocs/tcp-server-polling-test",
-    "pocs/tcp-server-polling-test/server",
-    "pocs/tcp-server-polling-test/client",
-    "pocs/tcp-server-polling-test/handler",
-
-
-    # ---------------------------------- #
-
-
-    # "pocs/network-component/tcp-client",
-    # "pocs/network-component/tcp-server",
-
-
-    # ---------------------------------- #
-
-
-    # "archive/shared/utils",
-    # "archive/paxos-v0.0.1/proposer",
-    # "archive/paxos-v0.0.1/acceptor",
-    # "archive/paxos-v0.0.1/command",
-
-    # "archive/paxos-v0.0.2/proposer", Doesn't compile
-    # "archive/paxos-v0.0.2/acceptor",
-    # "archive/paxos-v0.0.2/command",
-    # "archive/paxos-v0.0.2/grpc",
-
-    # "archive/paxos-v0.0.3/proposer",
-    # "archive/paxos-v0.0.3/acceptor",
-    # "archive/paxos-v0.0.3/grpc",
-
-    # "archive/simple-paxos-wasm",
-    # "archive/simple-paxos-wasm/proposer",
-    # "archive/simple-paxos-wasm/acceptor",
-    # "archive/simple-paxos-wasm/learner",
-
-    # "archive/wrpc_v1",
-    # "archive/wrpc_v1/proposer-wrpc",
-    # "archive/wrpc_v1/acceptor-wrpc",
-    # "archive/wrpc_v1/learner-wrpc",
-    # "archive/wrpc_v1/command-wrpc",
-
-    # "archive/wrpc_v2",
-    # "archive/wrpc_v2/command-wrpc",
-    # "archive/wrpc_v2/proposer-wrpc", Doesn't compile
-    # "archive/wrpc_v2/acceptor-wrpc",
-    # "archive/wrpc_v2/learner-wrpc",
-    # "archive/wrpc_v2/paxos-wrpc",
-
-    # "wasm-examples.../"
+  "paxos-rust", # "paxos-wasm",
+  "paxos-wasm/core",
+  "paxos-wasm/core/proposer",
+  "paxos-wasm/core/acceptor",
+  "paxos-wasm/core/learner",
+  "paxos-wasm/core/kv-store",
+  "paxos-wasm/core/leader-detector",
+  "paxos-wasm/core/failure-detector",
+  "paxos-wasm/agents",
+  "paxos-wasm/agents/proposer-agent",
+  "paxos-wasm/agents/acceptor-agent",
+  "paxos-wasm/agents/learner-agent",
+  "paxos-wasm/agents/kv-store-agent",
+  "paxos-wasm/runners",
+  "paxos-wasm/runners/paxos-coordinator",
+  "paxos-wasm/runners/runner",
+  "paxos-wasm/composed-grpc",
+  "paxos-wasm/composed-grpc/client",
+  "paxos-wasm/composed-grpc/client-cli",
+  "paxos-wasm/composed-grpc/command",
+  "paxos-wasm/network-ws",
+  "paxos-wasm/network-ws/serializer",
+  "paxos-wasm/network-ws/network-server",
+  "paxos-wasm/network-ws/client-server",
+  "paxos-wasm/network-ws/tcp-client", # "paxos-wasm/network-ws/udp-client",
+  "paxos-wasm/runner-ws", # TODO: Enable when fixed  # "paxos-wasm/modular-grpc",  # "paxos-wasm/modular-grpc/client",
+  "paxos-wasm/modular-ws",
+  "paxos-wasm/modular-ws/client",
+  "paxos-wasm/modular-ws/tcp-server", # "paxos-wasm/modular-ws/udp-server",
+  "paxos-wasm/modular-ws-client",
+  "paxos-wasm/modular-ws-client/paxos-ws-client",
+  "paxos-wasm/shared/utils",
+  "paxos-wasm/shared/grpc",
+  "paxos-wasm/shared/proto",
+  "pocs/tcp-server-polling-test",
+  "pocs/tcp-server-polling-test/server",
+  "pocs/tcp-server-polling-test/client",
+  "pocs/tcp-server-polling-test/handler",
+  "pocs/wasm-overhead/native",
+  "pocs/wasm-overhead/wasm", # ---------------------------------- #  # "pocs/network-component/tcp-client",  # "pocs/network-component/tcp-server",  # ---------------------------------- #  # "archive/shared/utils",  # "archive/paxos-v0.0.1/proposer",  # "archive/paxos-v0.0.1/acceptor",  # "archive/paxos-v0.0.1/command",  # "archive/paxos-v0.0.2/proposer", Doesn't compile  # "archive/paxos-v0.0.2/acceptor",  # "archive/paxos-v0.0.2/command",  # "archive/paxos-v0.0.2/grpc",  # "archive/paxos-v0.0.3/proposer",  # "archive/paxos-v0.0.3/acceptor",
+  # "archive/paxos-v0.0.3/grpc",
+  # "archive/simple-paxos-wasm",
+  # "archive/simple-paxos-wasm/proposer",
+  # "archive/simple-paxos-wasm/acceptor",
+  # "archive/simple-paxos-wasm/learner",
+  # "archive/wrpc_v1",
+  # "archive/wrpc_v1/proposer-wrpc",
+  # "archive/wrpc_v1/acceptor-wrpc",
+  # "archive/wrpc_v1/learner-wrpc",
+  # "archive/wrpc_v1/command-wrpc",
+  # "archive/wrpc_v2",
+  # "archive/wrpc_v2/command-wrpc",
+  # "archive/wrpc_v2/proposer-wrpc", Doesn't compile
+  # "archive/wrpc_v2/acceptor-wrpc",
+  # "archive/wrpc_v2/learner-wrpc",
+  # "archive/wrpc_v2/paxos-wrpc",
+  # "wasm-examples.../"
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:24.04
+
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY ./target/release/wasm-overhead-native /usr/local/bin/wasm-overhead-native
+
+RUN chmod +x /usr/local/bin/wasm-overhead-native
+
+ENTRYPOINT ["/usr/local/bin/wasm-overhead-native"]

--- a/paxos-wasm/agents/proposer-agent/src/proposer-agent.rs
+++ b/paxos-wasm/agents/proposer-agent/src/proposer-agent.rs
@@ -420,7 +420,7 @@ impl GuestProposerAgentResource for MyProposerAgentResource {
         ));
         let network_client = Arc::new(NetworkClientResource::new());
 
-        let batch_size = 20; // TODO: make part of config/input
+        let batch_size = config.batch_size; // TODO: make part of config/input
 
         Self {
             config,
@@ -603,7 +603,7 @@ impl GuestProposerAgentResource for MyProposerAgentResource {
     fn collect_client_responses(&self) -> Vec<ClientResponse> {
         let mut out = Vec::new();
         let mut queue = self.client_responses.borrow_mut();
-        for _ in 0..self.batch_size {
+        for _ in 0..self.config.executed_batch_size {
             if let Some((_, resp)) = queue.pop_first() {
                 out.push(resp);
             } else {

--- a/paxos-wasm/modular-ws-client/src/main.rs
+++ b/paxos-wasm/modular-ws-client/src/main.rs
@@ -122,10 +122,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let mut lats = Vec::with_capacity(args.num_requests);
             let start = Instant::now();
             let deadline = start + Duration::from_secs(args.timeout_secs);
+            let max_in_flight = 100;
 
             while (seen.len() as u64) < total && Instant::now() < deadline {
                 // Send request
-                if next < total {
+                if next < total && sent.len() < max_in_flight {
                     let req = Value {
                         client_id: args.client_id.to_string(),
                         client_seq: next,

--- a/paxos-wasm/network-ws/build.rs
+++ b/paxos-wasm/network-ws/build.rs
@@ -44,6 +44,13 @@ fn main() {
 
     // --- Build WS plugged Components ---
 
+    println!("BUILDING WASM OVERHEAD");
+    let build_list = &[];
+    let plugs = &["composed_network_server_tcp", "composed_tcp_client"];
+    let socket = "wasm-overhead-wasm";
+    let output = "composed_wasm_overhead";
+    build_and_plug(target, build_list, plugs, socket, output);
+
     let build_list_agents: &[&str] = &[];
     let plugs = &["composed_tcp_client"];
     let socket_proposer = "composed_proposer_agent";

--- a/paxos-wasm/network-ws/network-server/src/network_server_tcp.rs
+++ b/paxos-wasm/network-ws/network-server/src/network_server_tcp.rs
@@ -18,7 +18,7 @@ bindings::export!(MyNetworkServerTcp with_types_in bindings);
 
 use bindings::exports::paxos::default::network_server::{Guest, GuestNetworkServerResource};
 use bindings::paxos::default::network_types::NetworkMessage;
-use bindings::paxos::default::{logger, serializer};
+use bindings::paxos::default::serializer;
 
 struct MyNetworkServerTcp;
 struct MyNetworkServerTcpResource {
@@ -90,7 +90,9 @@ impl GuestNetworkServerResource for MyNetworkServerTcpResource {
                     }
                     Err(TcpErrorCode::WouldBlock) => break,
                     Err(e) => {
-                        logger::log_error(&format!("[Network Server] accept error: {:?}", e));
+                        // logger::log_error(&format!("[Network Server] accept error: {:?}", e));
+
+                        eprintln!("[Network Server] accept error: {:?}", e);
                         break;
                     }
                 }
@@ -132,10 +134,16 @@ impl GuestNetworkServerResource for MyNetworkServerTcpResource {
                     // Nothing to read. Can't be used to detect FIN/closed connection. Do nothing.
                 }
                 Err(e) => {
-                    logger::log_error(&format!(
+                    //     logger::log_error(&format!(
+                    //         "[Network Server] read error on chan {}: {:?}, dropping",
+                    //         chan, e
+                    //     ));
+
+                    eprintln!(
                         "[Network Server] read error on chan {}: {:?}, dropping",
                         chan, e
-                    ));
+                    );
+
                     to_drop.push(chan);
                 }
             }

--- a/paxos-wasm/network-ws/tcp-client/src/tcp-client.rs
+++ b/paxos-wasm/network-ws/tcp-client/src/tcp-client.rs
@@ -20,7 +20,7 @@ bindings::export!(TcpClient with_types_in bindings);
 use bindings::exports::paxos::default::network_client::{Guest, GuestNetworkClientResource};
 use bindings::paxos::default::network_types::NetworkMessage;
 use bindings::paxos::default::paxos_types::Node;
-use bindings::paxos::default::{logger, serializer};
+use bindings::paxos::default::serializer;
 
 /// Simple struct to hold our streams and keep the socket alive
 struct Connection {
@@ -77,13 +77,15 @@ impl GuestNetworkClientResource for TcpClientResource {
         for node in &nodes {
             let addr = &node.address;
             if let Err(e) = self.ensure_conn(addr) {
-                logger::log_warn(&format!("[TCP Client] connect {} failed: {:?}", addr, e));
+                // logger::log_warn(&format!("[TCP Client] connect {} failed: {:?}", addr, e));
+                eprintln!("[TCP Client] connect {} failed: {:?}", addr, e);
                 continue;
             }
             let mut conns = self.conns.borrow_mut();
             let conn = conns.get_mut(addr).unwrap();
             if conn.output.blocking_write_and_flush(&msg_bytes).is_err() {
-                logger::log_warn(&format!("[TCP Client] write to {} failed", addr));
+                // logger::log_warn(&format!("[TCP Client] write to {} failed", addr));
+                eprintln!("[TCP Client] write to {} failed", addr);
             }
         }
 
@@ -134,13 +136,15 @@ impl GuestNetworkClientResource for TcpClientResource {
         for node in &nodes {
             let addr = &node.address;
             if let Err(e) = self.ensure_conn(addr) {
-                logger::log_warn(&format!("[TCP Client] connect {} failed: {:?}", addr, e));
+                // logger::log_warn(&format!("[TCP Client] connect {} failed: {:?}", addr, e));
+                eprintln!("[TCP Client] connect {} failed: {:?}", addr, e);
                 continue;
             }
             let mut conns = self.conns.borrow_mut();
             let conn = conns.get_mut(addr).unwrap();
             if conn.output.blocking_write_and_flush(&msg_bytes).is_err() {
-                logger::log_warn(&format!("[TCP Client] write to {} failed (forget)", addr));
+                // logger::log_warn(&format!("[TCP Client] write to {} failed (forget)", addr));
+                eprintln!("[TCP Client] write to {} failed (forget)", addr);
             }
         }
     }

--- a/paxos-wasm/runner-ws/Cargo.toml
+++ b/paxos-wasm/runner-ws/Cargo.toml
@@ -1,24 +1,24 @@
 [package]
+edition = "2024"
 name = "runners-ws"
 version = "0.1.0"
-edition = "2024"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+base64 = "0.21"
+clap = {version = "4.5", features = ["derive"]}
+dashmap = "5"
+futures = "0.3"
+once_cell = "1"
+tempfile = "3"
+tokio = {version = "1", features = ["rt-multi-thread", "macros", "full"]}
+tracing = "0.1"
+tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 wasmtime = "31"
 wasmtime-wasi = "31"
-clap = { version = "4.5", features = ["derive"] }
-futures = "0.3"
-tempfile = "3"
-dashmap = "5"
-once_cell = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 yaml-rust = "0.4"
 
-
 [build-dependencies]
-paxos-wasm-utils = { path = "../shared/utils" }
-network-ws = { path = "../network-ws" }
-agents = { path = "../agents" }
-runners = { path = "../runners" }
+agents = {path = "../agents"}
+network-ws = {path = "../network-ws"}
+paxos-wasm-utils = {path = "../shared/utils"}
+runners = {path = "../runners"}

--- a/paxos-wasm/runner-ws/src/bindings.rs
+++ b/paxos-wasm/runner-ws/src/bindings.rs
@@ -3,5 +3,9 @@ wasmtime::component::bindgen! {{
     world: "paxos-runner-world",
     additional_derives: [Clone],
     async: true,
+    with: {
+        "paxos:default/network-server/network-server-resource": crate::paxos_wasm::NetworkServerResource,
+        "paxos:default/network-client/network-client-resource": crate::paxos_wasm::NetworkClientResource,
+    }
     // TODO: Try async again later
 }}

--- a/paxos-wasm/runner-ws/src/host_network_client.rs
+++ b/paxos-wasm/runner-ws/src/host_network_client.rs
@@ -1,0 +1,206 @@
+// use std::collections::HashMap;
+// use std::sync::{Arc, Mutex};
+// use tokio::io::{AsyncReadExt, AsyncWriteExt};
+// use tokio::net::TcpStream;
+// use tokio::sync::Mutex as AsyncMutex;
+
+// use crate::bindings::paxos::default::network_types::NetworkMessage;
+// use crate::bindings::paxos::default::paxos_types::Node;
+// use crate::serializer::{MySerializer, Serializer};
+
+// pub struct NativeTcpClient {
+//     conns: Arc<AsyncMutex<HashMap<String, TcpStream>>>,
+//     bufs: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+//     serializer: MySerializer,
+// }
+
+// impl NativeTcpClient {
+//     pub fn new() -> Self {
+//         Self {
+//             conns: Arc::new(AsyncMutex::new(HashMap::new())),
+//             bufs: Arc::new(Mutex::new(HashMap::new())),
+//             serializer: MySerializer,
+//         }
+//     }
+
+//     /// Ensures a connection exists to a given address.
+//     async fn ensure_conn(&self, addr: &str) -> std::io::Result<()> {
+//         let mut conns = self.conns.lock().await;
+//         if !conns.contains_key(addr) {
+//             let stream = TcpStream::connect(addr).await?;
+//             conns.insert(addr.to_string(), stream);
+//             self.bufs
+//                 .lock()
+//                 .unwrap()
+//                 .insert(addr.to_string(), Vec::new());
+//             println!("[Client] Connected to {}", addr);
+//         }
+//         Ok(())
+//     }
+
+//     /// Fire-and-forget message send; this method returns immediately.
+//     pub fn send_message_forget(&self, nodes: Vec<Node>, message: NetworkMessage) {
+//         let msg_bytes = self.serializer.serialize(message);
+//         let conns = Arc::clone(&self.conns);
+//         let this = self.clone();
+
+//         tokio::spawn(async move {
+//             for node in &nodes {
+//                 let addr = &node.address;
+//                 if this.ensure_conn(addr).await.is_err() {
+//                     continue;
+//                 }
+
+//                 let mut conns_guard = conns.lock().await;
+//                 if let Some(stream) = conns_guard.get_mut(addr) {
+//                     if let Err(e) = stream.write_all(&msg_bytes).await {
+//                         eprintln!("[Client] Write to {} failed (forget): {}", addr, e);
+//                     }
+//                 }
+//             }
+//         });
+//     }
+
+//     /// Synchronous-looking send message method that awaits a reply.
+//     pub fn send_message(&self, nodes: Vec<Node>, message: NetworkMessage) -> Vec<NetworkMessage> {
+//         let mut replies = vec![];
+//         // let mut frame = (message.len() as u32).to_be_bytes().to_vec();
+//         // frame.extend_from_slice(message);
+
+//         // let mut conns = self.conns.lock().await;
+
+//         // for node in &nodes {
+//         //     let addr = &node.address;
+
+//         //     if self.ensure_conn(addr).await.is_err() {
+//         //         continue;
+//         //     }
+
+//         //     if let Some(stream) = conns.get_mut(addr) {
+//         //         if let Err(e) = stream.write_all(&frame).await {
+//         //             eprintln!("[Client] Write to {} failed: {}", addr, e);
+//         //             continue;
+//         //         }
+
+//         //         let mut buf = [0u8; 4096];
+//         //         match stream.read(&mut buf).await {
+//         //             Ok(n) if n > 0 => {
+//         //                 let mut bufs = self.bufs.lock().unwrap();
+//         //                 let buffer = bufs.get_mut(addr).unwrap();
+//         //                 buffer.extend_from_slice(&buf[..n]);
+
+//         //                 let mut offset = 0;
+//         //                 while buffer.len() >= offset + 4 {
+//         //                     let len =
+//         //                         u32::from_be_bytes(buffer[offset..offset + 4].try_into().unwrap())
+//         //                             as usize;
+//         //                     if buffer.len() < offset + 4 + len {
+//         //                         break;
+//         //                     }
+//         //                     let mut frame = (len as u32).to_be_bytes().to_vec();
+//         //                     frame.extend_from_slice(&buffer[offset + 4..offset + 4 + len]);
+//         //                     offset += 4 + len;
+
+//         //                     let msg: NetworkMessage = self.serializer.deserialize(frame).unwrap();
+//         //                     replies.push(msg);
+//         //                 }
+
+//         //                 if offset > 0 {
+//         //                     buffer.drain(0..offset);
+//         //                 }
+//         //             }
+//         //             _ => {}
+//         //         }
+//         //     }
+//         // }
+
+//         replies
+//     }
+// }
+
+// // Implement Clone so the client can be passed into async tasks.
+// impl Clone for NativeTcpClient {
+//     fn clone(&self) -> Self {
+//         Self {
+//             conns: Arc::clone(&self.conns),
+//             bufs: Arc::clone(&self.bufs),
+//             serializer: self.serializer.clone(),
+//         }
+//     }
+// }
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::net::TcpStream;
+use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use crate::bindings::paxos::default::network_types::NetworkMessage;
+use crate::bindings::paxos::default::paxos_types::Node;
+use crate::serializer::{MySerializer, Serializer};
+
+pub struct NativeTcpClient {
+    tx: Sender<(String, Vec<u8>)>,
+}
+
+impl NativeTcpClient {
+    pub fn new() -> Self {
+        println!("[Client] Starting TCP client thread");
+        let (tx, rx) = mpsc::channel::<(String, Vec<u8>)>();
+        let serializer = MySerializer;
+        let conns = Arc::new(Mutex::new(HashMap::new()));
+
+        let conns_bg = Arc::clone(&conns);
+
+        thread::spawn(move || {
+            while let Ok((addr, msg)) = rx.recv() {
+                let mut conns = conns_bg.lock().unwrap();
+
+                let stream = conns.entry(addr.clone()).or_insert_with(|| {
+                    match TcpStream::connect(&addr) {
+                        Ok(s) => {
+                            s.set_nodelay(true).ok();
+                            s
+                        }
+                        Err(e) => {
+                            eprintln!("[Client] Failed to connect to {}: {}", addr, e);
+                            return TcpStream::connect("0.0.0.0:0").unwrap(); // dummy stream; real impl should skip
+                        }
+                    }
+                });
+
+                if let Err(e) = stream.write_all(&msg) {
+                    eprintln!("[Client] Failed to write to {}: {}", addr, e);
+                    conns.remove(&addr);
+                }
+            }
+        });
+
+        Self { tx }
+    }
+
+    pub fn send_message_forget(&self, nodes: Vec<Node>, message: NetworkMessage) {
+        let serializer = MySerializer;
+        let msg_bytes = serializer.serialize(message);
+
+        for node in nodes {
+            let addr = node.address;
+            let _ = self.tx.send((addr, msg_bytes.clone()));
+        }
+    }
+
+    pub fn send_message(&self, nodes: Vec<Node>, message: NetworkMessage) -> Vec<NetworkMessage> {
+        let serializer = MySerializer;
+        let msg_bytes = serializer.serialize(message);
+        let mut replies = vec![];
+
+        // for node in nodes {
+        //     let addr = node.address;
+        //     let _ = self.tx.send((addr, msg_bytes.clone()));
+        //     // Here we would normally wait for a reply, but this is a fire-and-forget example.
+        // }
+
+        replies
+    }
+}

--- a/paxos-wasm/runner-ws/src/host_network_server.rs
+++ b/paxos-wasm/runner-ws/src/host_network_server.rs
@@ -1,0 +1,246 @@
+// use crate::bindings::paxos::default::network_types::NetworkMessage;
+// use crate::serializer::{MySerializer, Serializer};
+// use std::sync::{Arc, Mutex};
+// use tokio::io::AsyncReadExt;
+// use tokio::net::TcpListener;
+// use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel};
+
+// pub struct NativeTcpServer {
+//     sender: UnboundedSender<NetworkMessage>,
+//     receiver: Arc<Mutex<UnboundedReceiver<NetworkMessage>>>,
+//     serializer: MySerializer,
+// }
+
+// impl NativeTcpServer {
+//     pub fn new() -> Self {
+//         let (sender, receiver) = unbounded_channel();
+//         Self {
+//             sender,
+//             receiver: Arc::new(Mutex::new(receiver)),
+//             serializer: MySerializer,
+//         }
+//     }
+
+//     /// Launches a dedicated thread with a Tokio runtime for the listener.
+//     pub fn setup_listener(&mut self, bind_addr: &str) {
+//         let addr = bind_addr.to_string();
+//         let serializer = self.serializer.clone();
+//         let sender = self.sender.clone();
+
+//         std::thread::spawn(move || {
+//             let rt = tokio::runtime::Builder::new_multi_thread()
+//                 .worker_threads(2)
+//                 .enable_all()
+//                 .build()
+//                 .expect("Failed to build Tokio runtime");
+
+//             rt.block_on(async move {
+//                 let listener = TcpListener::bind(&addr)
+//                     .await
+//                     .expect("Failed to bind listener");
+//                 println!("[Server] Listening on {}", addr);
+
+//                 loop {
+//                     match listener.accept().await {
+//                         Ok((mut stream, _)) => {
+//                             let serializer = serializer.clone();
+//                             let sender = sender.clone();
+
+//                             tokio::spawn(async move {
+//                                 let mut buf = vec![0u8; 4096];
+//                                 let mut buffer = Vec::new();
+
+//                                 loop {
+//                                     match stream.read(&mut buf).await {
+//                                         Ok(0) => {
+//                                             println!("[Server] Connection closed");
+//                                             break;
+//                                         }
+//                                         Ok(n) => {
+//                                             buffer.extend_from_slice(&buf[..n]);
+//                                             let mut offset = 0;
+
+//                                             while buffer.len() >= offset + 4 {
+//                                                 let len = u32::from_be_bytes(
+//                                                     buffer[offset..offset + 4].try_into().unwrap(),
+//                                                 )
+//                                                     as usize;
+
+//                                                 if buffer.len() < offset + 4 + len {
+//                                                     break;
+//                                                 }
+
+//                                                 let mut frame = (len as u32).to_be_bytes().to_vec();
+//                                                 frame.extend_from_slice(
+//                                                     &buffer[offset + 4..offset + 4 + len],
+//                                                 );
+//                                                 offset += 4 + len;
+
+//                                                 match serializer.deserialize(frame) {
+//                                                     Ok(msg) => {
+//                                                         let _ = sender.send(msg);
+//                                                     }
+//                                                     Err(e) => {
+//                                                         eprintln!(
+//                                                             "[Server] Deserialize error: {:?}",
+//                                                             e
+//                                                         );
+//                                                     }
+//                                                 }
+//                                             }
+
+//                                             if offset > 0 {
+//                                                 buffer.drain(0..offset);
+//                                             }
+//                                         }
+//                                         Err(e) => {
+//                                             eprintln!("[Server] Read error: {}", e);
+//                                             break;
+//                                         }
+//                                     }
+//                                 }
+//                             });
+//                         }
+//                         Err(e) => {
+//                             eprintln!("[Server] Accept error: {}", e);
+//                         }
+//                     }
+//                 }
+//             });
+//         });
+//     }
+
+//     /// Drains all received messages from the queue.
+//     pub fn get_messages(&self) -> Vec<NetworkMessage> {
+//         let mut rx = self.receiver.lock().unwrap();
+//         let mut out = Vec::new();
+
+//         while let Ok(msg) = rx.try_recv() {
+//             out.push(msg);
+//         }
+
+//         out
+//     }
+
+//     pub fn get_message(&self) -> Option<NetworkMessage> {
+//         self.get_messages().into_iter().next()
+//     }
+// }
+use std::collections::{HashMap, VecDeque};
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crate::bindings::paxos::default::network_types::NetworkMessage;
+use crate::serializer::{MySerializer, Serializer};
+
+pub struct NativeTcpServer {
+    messages: Arc<Mutex<VecDeque<NetworkMessage>>>,
+}
+
+impl NativeTcpServer {
+    pub fn new() -> Self {
+        Self {
+            messages: Arc::new(Mutex::new(VecDeque::new())),
+        }
+    }
+
+    pub fn setup_listener(&mut self, bind_addr: &str) {
+        let listener = TcpListener::bind(bind_addr).expect("failed to bind listener");
+        listener
+            .set_nonblocking(true)
+            .expect("failed to set non-blocking");
+        println!("[Server] Listening on {}", bind_addr);
+
+        let messages = Arc::clone(&self.messages);
+
+        thread::spawn(move || {
+            let mut next_id = 1u64;
+            let mut conns: HashMap<u64, TcpStream> = HashMap::new();
+            let mut buffers: HashMap<u64, Vec<u8>> = HashMap::new();
+            let serializer = MySerializer;
+
+            loop {
+                // Accept new connections
+                match listener.accept() {
+                    Ok((mut stream, _addr)) => {
+                        stream.set_nonblocking(true).unwrap();
+                        let id = next_id;
+                        next_id += 1;
+                        conns.insert(id, stream);
+                        buffers.insert(id, Vec::new());
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {} // No new connection
+                    Err(e) => {
+                        eprintln!("[Server] Accept error: {}", e);
+                    }
+                }
+
+                let mut to_remove = vec![];
+
+                // Read from all connections
+                for (&id, stream) in conns.iter_mut() {
+                    let mut buf = [0u8; 4096];
+                    match stream.read(&mut buf) {
+                        Ok(0) => {
+                            // Connection closed
+                            to_remove.push(id);
+                        }
+                        Ok(n) => {
+                            let b = buffers.get_mut(&id).unwrap();
+                            b.extend_from_slice(&buf[..n]);
+
+                            let mut offset = 0;
+                            while b.len() >= offset + 4 {
+                                let len =
+                                    u32::from_be_bytes(b[offset..offset + 4].try_into().unwrap())
+                                        as usize;
+
+                                if b.len() < offset + 4 + len {
+                                    break;
+                                }
+
+                                let mut frame = (len as u32).to_be_bytes().to_vec();
+                                frame.extend_from_slice(&b[offset + 4..offset + 4 + len]);
+                                offset += 4 + len;
+
+                                if let Ok(msg) = serializer.deserialize(frame) {
+                                    messages.lock().unwrap().push_back(msg);
+                                } else {
+                                    eprintln!("[Server] Failed to deserialize message from {}", id);
+                                }
+                            }
+
+                            if offset > 0 {
+                                b.drain(0..offset);
+                            }
+                        }
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                        Err(e) => {
+                            eprintln!("[Server] Read error on {}: {}", id, e);
+                            to_remove.push(id);
+                        }
+                    }
+                }
+
+                for id in to_remove {
+                    conns.remove(&id);
+                    buffers.remove(&id);
+                }
+
+                thread::sleep(Duration::from_millis(1)); // Prevent busy spinning
+            }
+        });
+    }
+
+    pub fn get_messages(&self) -> Vec<NetworkMessage> {
+        let mut queue = self.messages.lock().unwrap();
+        queue.drain(..).collect()
+    }
+
+    pub fn get_message(&self) -> Option<NetworkMessage> {
+        self.messages.lock().unwrap().pop_front()
+    }
+}

--- a/paxos-wasm/runner-ws/src/main.rs
+++ b/paxos-wasm/runner-ws/src/main.rs
@@ -3,6 +3,10 @@ mod config;
 mod host_logger;
 mod paxos_wasm;
 
+pub mod host_network_client;
+pub mod host_network_server;
+pub mod serializer;
+
 use clap::Parser;
 use config::Config;
 use paxos_wasm::PaxosWasmtime;

--- a/paxos-wasm/runner-ws/src/paxos_wasm.rs
+++ b/paxos-wasm/runner-ws/src/paxos_wasm.rs
@@ -2,9 +2,14 @@ use std::error::Error;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use wasmtime::component::{Component, Linker, ResourceAny};
+use wasmtime::component::{Component, Linker, Resource, ResourceAny};
 use wasmtime::{Engine, Store};
+use wasmtime_wasi::bindings::cli;
 use wasmtime_wasi::{IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
+
+use crate::bindings::exports::paxos;
+use crate::host_network_client::NativeTcpClient;
+use crate::host_network_server::NativeTcpServer;
 
 use crate::bindings;
 use crate::bindings::paxos::default::paxos_types::{Node, RunConfig};
@@ -34,7 +39,7 @@ impl ComponentRunStates {
         let host_node = host_logger::HostNode {
             node_id: node.node_id,
             address: node.address.clone(),
-            role: node.role as u64, 
+            role: node.role as u64,
         };
         ComponentRunStates {
             wasi_ctx: WasiCtxBuilder::new()
@@ -48,6 +53,14 @@ impl ComponentRunStates {
             logger: Arc::new(HostLogger::new_from_workspace(host_node)),
         }
     }
+}
+
+pub struct NetworkServerResource {
+    pub server: NativeTcpServer,
+}
+
+pub struct NetworkClientResource {
+    pub client: NativeTcpClient,
 }
 
 pub struct PaxosWasmtime {
@@ -75,6 +88,8 @@ impl PaxosWasmtime {
         wasmtime_wasi::add_to_linker_async(&mut linker)?;
 
         bindings::paxos::default::logger::add_to_linker(&mut linker, |s| s)?;
+        bindings::paxos::default::network_server::add_to_linker(&mut linker, |s| s)?;
+        bindings::paxos::default::network_client::add_to_linker(&mut linker, |s| s)?;
 
         let workspace_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
@@ -119,14 +134,94 @@ impl PaxosWasmtime {
     }
 }
 
+impl bindings::paxos::default::network_server::Host for ComponentRunStates {}
+
+impl bindings::paxos::default::network_server::HostNetworkServerResource for ComponentRunStates {
+    async fn new(&mut self) -> Resource<NetworkServerResource> {
+        let server = self.resource_table.push(NetworkServerResource {
+            server: NativeTcpServer::new(),
+        });
+        server.unwrap()
+    }
+
+    async fn setup_listener(
+        &mut self,
+        resource: Resource<NetworkServerResource>,
+        bind_addr: String,
+    ) {
+        let server = self.resource_table.get_mut(&resource).unwrap();
+        server.server.setup_listener(&bind_addr);
+    }
+
+    async fn get_messages(
+        &mut self,
+        resource: Resource<NetworkServerResource>,
+    ) -> Vec<bindings::paxos::default::network_types::NetworkMessage> {
+        let server = self.resource_table.get_mut(&resource).unwrap();
+        server.server.get_messages()
+    }
+
+    async fn get_message(
+        &mut self,
+        self_: wasmtime::component::Resource<NetworkServerResource>,
+    ) -> Option<bindings::paxos::default::network_server::NetworkMessage> {
+        let server = self.resource_table.get_mut(&self_).unwrap();
+        server.server.get_message()
+    }
+
+    async fn drop(
+        &mut self,
+        rep: wasmtime::component::Resource<NetworkServerResource>,
+    ) -> wasmtime::Result<()> {
+        let _ = self.resource_table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl bindings::paxos::default::network_client::HostNetworkClientResource for ComponentRunStates {
+    async fn new(&mut self) -> Resource<NetworkClientResource> {
+        let client = self.resource_table.push(NetworkClientResource {
+            client: NativeTcpClient::new(),
+        });
+        client.unwrap()
+    }
+
+    async fn send_message(
+        &mut self,
+        resource: Resource<NetworkClientResource>,
+        node: Vec<Node>,
+        message: bindings::paxos::default::network_client::NetworkMessage,
+    ) -> Vec<bindings::paxos::default::network_types::NetworkMessage> {
+        let client = self.resource_table.get_mut(&resource).unwrap();
+        client.client.send_message(node, message)
+    }
+
+    async fn send_message_forget(
+        &mut self,
+        resource: Resource<NetworkClientResource>,
+        node: Vec<Node>,
+        message: bindings::paxos::default::network_client::NetworkMessage,
+    ) {
+        let client = self.resource_table.get_mut(&resource).unwrap();
+        client.client.send_message_forget(node, message)
+    }
+
+    async fn drop(&mut self, rep: Resource<NetworkClientResource>) -> wasmtime::Result<()> {
+        let _ = self.resource_table.delete(rep)?;
+        Ok(())
+    }
+}
+
+impl bindings::paxos::default::network_client::Host for ComponentRunStates {}
+
 impl bindings::paxos::default::logger::Host for ComponentRunStates {
     // Delegate the log calls to our stored HostLogger.
     async fn log_debug(&mut self, msg: String) {
-        self.logger.log_debug(msg);
+        // self.logger.log_debug(msg);
     }
 
     async fn log_info(&mut self, msg: String) {
-        self.logger.log_info(msg);
+        // self.logger.log_info(msg);
     }
 
     async fn log_warn(&mut self, msg: String) {

--- a/paxos-wasm/runner-ws/src/serializer.rs
+++ b/paxos-wasm/runner-ws/src/serializer.rs
@@ -1,25 +1,40 @@
-pub mod bindings {
-    wit_bindgen::generate!({
-        path: "../../shared/wit",
-        world: "serializer-world",
-        additional_derives: [PartialEq, Clone],
-    });
-}
-
-bindings::export!(MySerializer with_types_in bindings);
-
-use bindings::exports::paxos::default::serializer::Guest;
-// use bindings::paxos::default::logger;
-use bindings::paxos::default::network_types::{
+use crate::bindings::paxos::default::network_types::{
     Benchmark, Heartbeat, MessagePayload, NetworkMessage,
 };
-use bindings::paxos::default::paxos_types::{
+use crate::bindings::paxos::default::paxos_types::{
     Accept, Accepted, ClientResponse, CmdResult, ExecuteResult, Executed, KvPair, Learn, Node,
     Operation, PValue, PaxosRole, Prepare, Promise, Value,
 };
 
-/// Helper function that attempts to deserialize and returns a Result.
-/// If any step fails, an error string is returned.
+pub trait Serializer {
+    fn serialize(&self, message: NetworkMessage) -> Vec<u8>;
+    fn deserialize(&self, bytes: Vec<u8>) -> Result<NetworkMessage, String>;
+}
+
+/// Native Rust implementation of the Serializer
+
+#[derive(Clone)]
+pub struct MySerializer;
+
+impl Serializer for MySerializer {
+    fn serialize(&self, message: NetworkMessage) -> Vec<u8> {
+        let sender_str = serialize_node(&message.sender);
+        let payload_str = serialize_message_payload(&message.payload);
+        let formatted = format!("sender={}||payload={}", sender_str, payload_str);
+        let payload_bytes = formatted.into_bytes();
+
+        let len: u32 = payload_bytes.len().try_into().expect("Message too long");
+        let mut out = Vec::with_capacity(4 + payload_bytes.len());
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&payload_bytes);
+        out
+    }
+
+    fn deserialize(&self, serialized: Vec<u8>) -> Result<NetworkMessage, String> {
+        try_deserialize(serialized)
+    }
+}
+
 fn try_deserialize(serialized: Vec<u8>) -> Result<NetworkMessage, String> {
     if serialized.len() < 4 {
         return Err("Serialized message too short to contain length prefix".to_string());
@@ -66,36 +81,6 @@ fn try_deserialize(serialized: Vec<u8>) -> Result<NetworkMessage, String> {
     Ok(NetworkMessage { sender, payload })
 }
 
-pub struct MySerializer;
-
-impl Guest for MySerializer {
-    fn serialize(message: NetworkMessage) -> Vec<u8> {
-        let sender_str = serialize_node(&message.sender);
-        let payload_str = serialize_message_payload(&message.payload);
-        let formatted = format!("sender={}||payload={}", sender_str, payload_str);
-        let payload_bytes = formatted.into_bytes();
-
-        // Compute length as a u32.
-        let len: u32 = payload_bytes.len().try_into().expect("Message too long");
-
-        // Allocate space: 4 bytes for the length prefix + the actual payload.
-        let mut out = Vec::with_capacity(4 + payload_bytes.len());
-        out.extend_from_slice(&len.to_be_bytes());
-        out.extend_from_slice(&payload_bytes);
-        out
-    }
-
-    fn deserialize(serialized: Vec<u8>) -> NetworkMessage {
-        match try_deserialize(serialized) {
-            Ok(msg) => msg,
-            Err(e) => {
-                panic!("[Serializer] Deserialization error: {}", e);
-            }
-        }
-    }
-}
-
-/// Serialize a Node
 fn serialize_node(n: &Node) -> String {
     let role_str = match n.role {
         PaxosRole::Proposer => "proposer",
@@ -696,10 +681,12 @@ fn deserialize_message_payload(s: &str) -> Result<MessagePayload, &'static str> 
             }
 
             if let (Some(ts), Some(p)) = (send_timestamp, payload_str) {
-                Ok(MessagePayload::Benchmark(Benchmark {
-                    send_timestamp: ts,
-                    payload: p,
-                }))
+                Ok(MessagePayload::Benchmark(
+                    crate::bindings::paxos::default::network_types::Benchmark {
+                        send_timestamp: ts,
+                        payload: p,
+                    },
+                ))
             } else {
                 Err("bad benchmark message")
             }

--- a/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
+++ b/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
@@ -347,6 +347,13 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
                 ));
                 ignore_msg
             }
+            _ => {
+                logger::log_warn(&format!(
+                    "[Coordinator] Received unknown message type: {:?}",
+                    message.payload
+                ));
+                ignore_msg
+            }
         }
     }
 

--- a/paxos-wasm/shared/wit/types.wit
+++ b/paxos-wasm/shared/wit/types.wit
@@ -259,7 +259,13 @@ interface network-types {
         // learn-ack(learn),                // A learn ack. // TODO: Use or not to use, with custom payload? 
         heartbeat(heartbeat),               // Heartbeat.
         executed(executed),                 // Contains list of executed values and adu.
-        retry-learn(slot),                  // Retry learn for missing slot
+        retry-learn(slot),              // Retry learn for missing slot
+        benchmark(benchmark),           // Benchmark message
+    }
+
+    record benchmark {
+        send-timestamp: u64,
+        payload: string,
     }
 
     record heartbeat {

--- a/paxos-wasm/shared/wit/worlds.wit
+++ b/paxos-wasm/shared/wit/worlds.wit
@@ -84,6 +84,7 @@ world paxos-coordinator-world {
 world paxos-runner-world {
     import client-server;
     import network-server;
+    import network-client;
     import paxos-coordinator;
     
     import logger;
@@ -94,14 +95,14 @@ world paxos-runner-world {
 // Network
 
 world serializer-world {
-    // import logger;
+    import logger;
     
     export serializer;
 }
 
 world network-client-world {
     import serializer;
-    import logger;
+    // import logger;
     export network-client;
 }
 
@@ -119,13 +120,13 @@ world paxos-ws-world {
 
 world paxos-client-world {
     import serializer;
-    // import logger;
+    import logger;
     export paxos-client;
 }
 
 world network-server-world {
     import serializer;
-    import logger;
+    // import logger;
     export network-server;
 }
 
@@ -133,4 +134,9 @@ world client-server-world {
     import serializer;
     import logger;
     export client-server;
+}
+
+world wasm-overhead-world {
+    import network-client;
+    import network-server;
 }

--- a/pocs/wasm-overhead/native/Cargo.toml
+++ b/pocs/wasm-overhead/native/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition = "2024"
+name = "wasm-overhead-native"
+version = "0.1.0"
+
+[dependencies]
+anyhow = "1.0.97"
+
+tokio = {version = "1.44.1", features = ["macros", "rt"]}
+
+wasmtime = "31"
+wasmtime-wasi = "31"

--- a/pocs/wasm-overhead/native/src/bindings.rs
+++ b/pocs/wasm-overhead/native/src/bindings.rs
@@ -1,0 +1,7 @@
+wasmtime::component::bindgen! {{
+    path: "../../../paxos-wasm/shared/wit",
+    world: "paxos-runner-world",
+    additional_derives: [Clone],
+    async: true,
+    // TODO: Try async again later
+}}

--- a/pocs/wasm-overhead/native/src/host_network_client.rs
+++ b/pocs/wasm-overhead/native/src/host_network_client.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+
+use crate::bindings::paxos::default::network_types::NetworkMessage;
+use crate::bindings::paxos::default::paxos_types::Node;
+
+use crate::serializer::{MySerializer, Serializer};
+
+pub struct NativeTcpClient {
+    conns: HashMap<String, TcpStream>,
+    bufs: HashMap<String, Vec<u8>>,
+    serializer: MySerializer,
+}
+
+impl NativeTcpClient {
+    pub fn new() -> Self {
+        Self {
+            conns: HashMap::new(),
+            bufs: HashMap::new(),
+            serializer: MySerializer,
+        }
+    }
+
+    fn ensure_conn(&mut self, addr: &str) -> std::io::Result<()> {
+        if !self.conns.contains_key(addr) {
+            let mut stream = TcpStream::connect(addr)?;
+            stream.set_nodelay(true)?;
+            stream.set_nonblocking(true)?;
+            self.conns.insert(addr.to_string(), stream);
+            self.bufs.insert(addr.to_string(), vec![]);
+            println!("[Client] Connected to {}", addr);
+        }
+        Ok(())
+    }
+
+    pub fn send_message_forget(&mut self, nodes: Vec<Node>, message: NetworkMessage) {
+        let msg_bytes = self.serializer.serialize(message.clone());
+
+        for node in &nodes {
+            let addr = &node.address;
+            if self.ensure_conn(addr).is_err() {
+                continue;
+            }
+
+            if let Some(stream) = self.conns.get_mut(addr) {
+                if let Err(e) = stream.write_all(&msg_bytes) {
+                    eprintln!("[Client] Write to {} failed (forget): {}", addr, e);
+                }
+            }
+        }
+    }
+
+    pub fn send_message(&mut self, nodes: Vec<Node>, message: &[u8]) -> Vec<NetworkMessage> {
+        let mut replies = vec![];
+        let mut frame = (message.len() as u32).to_be_bytes().to_vec();
+        frame.extend_from_slice(message);
+
+        for node in &nodes {
+            let addr = &node.address;
+            if self.ensure_conn(addr).is_err() {
+                continue;
+            }
+
+            if let Some(stream) = self.conns.get_mut(addr) {
+                if let Err(e) = stream.write_all(&frame) {
+                    eprintln!("[Client] Write to {} failed: {}", addr, e);
+                }
+            }
+
+            if let Some(stream) = self.conns.get_mut(addr) {
+                let buf = self.bufs.get_mut(addr).unwrap();
+                let mut chunk = [0u8; 4096];
+                match stream.read(&mut chunk) {
+                    Ok(n) if n > 0 => {
+                        buf.extend_from_slice(&chunk[..n]);
+                        let mut offset = 0;
+                        while buf.len() >= offset + 4 {
+                            let len =
+                                u32::from_be_bytes(buf[offset..offset + 4].try_into().unwrap())
+                                    as usize;
+                            if buf.len() < offset + 4 + len {
+                                break;
+                            }
+                            let mut frame = (len as u32).to_be_bytes().to_vec();
+                            frame.extend_from_slice(&buf[offset + 4..offset + 4 + len]);
+                            offset += 4 + len;
+
+                            let msg: NetworkMessage = self.serializer.deserialize(frame).unwrap();
+                            replies.push(msg);
+                        }
+                        if offset > 0 {
+                            buf.drain(0..offset);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        replies
+    }
+}

--- a/pocs/wasm-overhead/native/src/host_network_server.rs
+++ b/pocs/wasm-overhead/native/src/host_network_server.rs
@@ -1,0 +1,110 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
+
+use crate::serializer::{MySerializer, Serializer};
+
+use crate::bindings::paxos::default::network_types::NetworkMessage;
+
+pub struct NativeTcpServer {
+    listener: Option<TcpListener>,
+    next_id: u64,
+    conns: HashMap<u64, TcpStream>,
+    buffers: HashMap<u64, Vec<u8>>,
+    serializer: MySerializer,
+}
+
+impl NativeTcpServer {
+    pub fn new() -> Self {
+        Self {
+            listener: None,
+            next_id: 1,
+            conns: HashMap::new(),
+            buffers: HashMap::new(),
+            serializer: MySerializer,
+        }
+    }
+
+    pub fn setup_listener(&mut self, bind_addr: &str) {
+        let listener = TcpListener::bind(bind_addr).expect("failed to bind listener");
+        listener
+            .set_nonblocking(true)
+            .expect("failed to set non-blocking");
+        self.listener = Some(listener);
+        println!("[Server] Listening on {}", bind_addr);
+    }
+
+    pub fn get_messages(&mut self) -> Vec<NetworkMessage> {
+        let mut messages = vec![];
+        let mut to_remove = vec![];
+
+        // Accept new connections
+        if let Some(listener) = self.listener.as_ref() {
+            loop {
+                match listener.accept() {
+                    Ok((stream, _addr)) => {
+                        stream.set_nonblocking(true).unwrap();
+                        let id = self.next_id;
+                        self.next_id += 1;
+                        self.conns.insert(id, stream);
+                        self.buffers.insert(id, vec![]);
+                    }
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                    Err(e) => {
+                        eprintln!("[Server] Accept error: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Read from connections
+
+        for (&id, stream) in self.conns.iter_mut() {
+            let mut buf = [0u8; 4096];
+            match stream.read(&mut buf) {
+                Ok(0) => to_remove.push(id),
+                Ok(n) => {
+                    let b = self.buffers.get_mut(&id).unwrap();
+                    b.extend_from_slice(&buf[..n]);
+
+                    let mut offset = 0;
+                    while b.len() >= offset + 4 {
+                        let len =
+                            u32::from_be_bytes(b[offset..offset + 4].try_into().unwrap()) as usize;
+                        if b.len() < offset + 4 + len {
+                            break;
+                        }
+                        let mut frame = (len as u32).to_be_bytes().to_vec();
+                        frame.extend_from_slice(&b[offset + 4..offset + 4 + len]);
+                        offset += 4 + len;
+
+                        let msg = self.serializer.deserialize(frame).unwrap();
+                        messages.push(msg);
+                    }
+
+                    if offset > 0 {
+                        b.drain(0..offset);
+                    }
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(e) => {
+                    eprintln!("[Server] Read error on {}: {}", id, e);
+                    to_remove.push(id);
+                }
+            }
+        }
+
+        for id in to_remove {
+            self.conns.remove(&id);
+            self.buffers.remove(&id);
+        }
+
+        messages
+    }
+
+    pub fn get_message(&mut self) -> Option<NetworkMessage> {
+        self.get_messages().into_iter().next()
+    }
+}

--- a/pocs/wasm-overhead/native/src/main.rs
+++ b/pocs/wasm-overhead/native/src/main.rs
@@ -1,0 +1,325 @@
+mod bindings;
+mod host_network_client;
+mod host_network_server;
+mod serializer;
+
+use bindings::paxos::default::network_types::NetworkMessage;
+use bindings::paxos::default::paxos_types::Node;
+use bindings::paxos::default::{
+    network_types::{Benchmark, MessagePayload},
+    paxos_types,
+};
+
+use host_network_client::NativeTcpClient;
+use host_network_server::NativeTcpServer;
+
+use std::env;
+use std::thread::sleep;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn current_time_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn dummy_payload() -> String {
+    "HELLO WORLD".to_string()
+}
+
+fn get_listener_address(port: u16, docker: bool) -> String {
+    if docker {
+        format!("0.0.0.0:{}", port)
+    } else {
+        format!("127.0.0.1:{}", port)
+    }
+}
+
+fn get_target_address(docker: bool, container_name: &str, port: u16) -> String {
+    if docker {
+        format!("{}:{}", container_name, port)
+    } else {
+        format!("127.0.0.1:{}", port)
+    }
+}
+
+pub fn run_latency_test(docker: bool) {
+    const MESSAGES_PER_BATCH: usize = 10;
+    const BATCHES: usize = 100;
+    const INTERVAL_BETWEEN_BATCHES_MS: u64 = 100;
+
+    let mut server = NativeTcpServer::new();
+    server.setup_listener(&get_listener_address(9000, docker));
+
+    let mut client = NativeTcpClient::new();
+
+    let node = Node {
+        node_id: 1,
+        address: get_target_address(docker, "node-b", 9001),
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    let mut rtt_samples = vec![];
+
+    for batch in 0..BATCHES {
+        let mut sent_timestamps = vec![];
+
+        for _ in 0..MESSAGES_PER_BATCH {
+            let now = current_time_micros();
+            let msg = NetworkMessage {
+                sender: node.clone(),
+                payload: MessagePayload::Benchmark(Benchmark {
+                    send_timestamp: now,
+                    payload: dummy_payload(),
+                }),
+            };
+
+            sent_timestamps.push(now);
+            client.send_message_forget(vec![node.clone()], msg);
+        }
+
+        let mut received = 0;
+        let start_wait = std::time::Instant::now();
+        while start_wait.elapsed() < Duration::from_millis(50) {
+            let messages = server.get_messages();
+            for msg in messages {
+                if let MessagePayload::Benchmark(pay) = msg.payload {
+                    let rtt = current_time_micros() - pay.send_timestamp;
+                    rtt_samples.push(rtt);
+                    received += 1;
+                }
+            }
+            sleep(Duration::from_millis(1));
+        }
+
+        println!("[Batch {}] Received {} responses", batch + 1, received);
+        sleep(Duration::from_millis(INTERVAL_BETWEEN_BATCHES_MS));
+    }
+
+    println!("\n=== RTT Results ===");
+    for (i, rtt) in rtt_samples.iter().enumerate() {
+        println!("Message {}: RTT = {} μs", i + 1, rtt);
+    }
+
+    let avg = rtt_samples.iter().sum::<u64>() as f64 / rtt_samples.len().max(1) as f64;
+    println!("Average RTT: {:.2} μs", avg);
+}
+
+pub fn run_throughput_test(docker: bool) {
+    use std::time::Instant;
+
+    const TEST_DURATION_SECS: u64 = 5;
+    const MAX_REQUESTS: usize = 1000;
+
+    let mut server = Some(NativeTcpServer::new());
+    let mut client = Some(NativeTcpClient::new());
+
+    server
+        .as_mut()
+        .unwrap()
+        .setup_listener(&get_listener_address(9000, docker));
+
+    let node = Node {
+        node_id: 1,
+        address: get_target_address(docker, "node-b", 9001),
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    let mut sent = 0;
+    let mut received = 0;
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(TEST_DURATION_SECS);
+
+    while Instant::now() < deadline {
+        // Send next message if under cap
+        if sent < MAX_REQUESTS {
+            let msg = NetworkMessage {
+                sender: node.clone(),
+                payload: MessagePayload::Benchmark(Benchmark {
+                    send_timestamp: 0,
+                    payload: dummy_payload(),
+                }),
+            };
+
+            client
+                .as_mut()
+                .unwrap()
+                .send_message_forget(vec![node.clone()], msg);
+
+            sent += 1;
+        }
+
+        // Try to receive any responses
+        let messages = server.as_mut().unwrap().get_messages();
+        for msg in messages {
+            if let MessagePayload::Benchmark(_) = msg.payload {
+                received += 1;
+            }
+        }
+        if received >= sent {
+            break;
+        }
+    }
+
+    // Final drain pass for any stragglers
+    let drain_end = Instant::now() + Duration::from_millis(20000);
+    while Instant::now() < drain_end {
+        let messages = server.as_mut().unwrap().get_messages();
+        for msg in messages {
+            if let MessagePayload::Benchmark(_) = msg.payload {
+                received += 1;
+            }
+        }
+        if received >= sent {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    let duration = Instant::now().duration_since(start).as_secs_f64();
+    let throughput = received as f64 / duration;
+
+    println!("\n=== Time-Based Throughput Test Results ===");
+    println!("Duration:  {:.2} seconds", duration);
+    println!("Sent:      {}", sent);
+    println!("Received:  {}", received);
+    println!("Throughput: {:.2} messages/sec", throughput);
+
+    drop(client.take());
+    drop(server.take());
+}
+
+pub fn run_latency_rtt_isolated(docker: bool) {
+    const TOTAL_MESSAGES: usize = 1000;
+    const RESPONSE_TIMEOUT_MS: u64 = 100;
+
+    let mut server = Some(NativeTcpServer::new());
+    let mut client = Some(NativeTcpClient::new());
+
+    server
+        .as_mut()
+        .unwrap()
+        .setup_listener(&get_listener_address(9000, docker));
+
+    let node = Node {
+        node_id: 1,
+        address: get_target_address(docker, "node-b", 9001),
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    let mut rtt_samples = vec![];
+
+    for i in 0..TOTAL_MESSAGES {
+        let now = current_time_micros();
+        let msg = NetworkMessage {
+            sender: node.clone(),
+            payload: MessagePayload::Benchmark(Benchmark {
+                send_timestamp: now,
+                payload: dummy_payload(),
+            }),
+        };
+
+        let start = std::time::Instant::now();
+        client
+            .as_mut()
+            .unwrap()
+            .send_message_forget(vec![node.clone()], msg);
+
+        let timeout = std::time::Instant::now() + Duration::from_millis(RESPONSE_TIMEOUT_MS);
+        loop {
+            let messages = server.as_mut().unwrap().get_messages();
+            if messages
+                .iter()
+                .any(|m| matches!(m.payload, MessagePayload::Benchmark(_)))
+            {
+                let rtt = current_time_micros() - now;
+                rtt_samples.push(rtt);
+                println!("Message {}: RTT = {} μs", i + 1, rtt);
+                break;
+            }
+
+            if std::time::Instant::now() >= timeout {
+                println!("Message {}: Timed out", i + 1);
+                break;
+            }
+
+            std::thread::sleep(Duration::from_micros(100));
+        }
+    }
+
+    let avg = rtt_samples.iter().sum::<u64>() as f64 / rtt_samples.len().max(1) as f64;
+    println!("\n=== Isolated RTT Results ===");
+    println!("Samples: {}", rtt_samples.len());
+    println!("Average RTT: {:.2} μs", avg);
+
+    drop(client.take());
+    drop(server.take());
+}
+
+pub fn run_echo_responder(docker: bool) {
+    println!("Echo with fib");
+    let mut server = NativeTcpServer::new();
+    server.setup_listener(&get_listener_address(9001, docker));
+
+    let mut client = NativeTcpClient::new();
+    let target = Node {
+        node_id: 0,
+        address: get_target_address(docker, "node-a", 9000),
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    println!(
+        "[Responder] Listening on {}",
+        get_listener_address(9001, docker)
+    );
+
+    loop {
+        let messages = server.get_messages();
+        for msg in messages {
+            // let _ = fib(35); // Simulate some work
+            if let MessagePayload::Benchmark(b) = msg.payload {
+                let response = NetworkMessage {
+                    sender: target.clone(),
+                    payload: MessagePayload::Benchmark(b.clone()),
+                };
+                client.send_message_forget(vec![target.clone()], response);
+            }
+        }
+        sleep(Duration::from_millis(1));
+    }
+}
+
+fn fib(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fib(n - 1) + fib(n - 2),
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 2 {
+        eprintln!("Usage: {} <mode> [--docker]", args[0]);
+        eprintln!("  0 = run_echo_responder");
+        eprintln!("  1 = run_latency_test");
+        eprintln!("  2 = run_throughput_test");
+        eprintln!("  3 = run_latency_rtt_isolated");
+        std::process::exit(1);
+    }
+
+    let docker = args.iter().any(|a| a == "--docker");
+
+    match args[1].as_str() {
+        "0" => run_echo_responder(docker),
+        "1" => run_latency_test(docker),
+        "2" => run_throughput_test(docker),
+        "3" => run_latency_rtt_isolated(docker),
+        _ => {
+            eprintln!("Invalid mode '{}'", args[1]);
+            std::process::exit(1);
+        }
+    }
+}

--- a/pocs/wasm-overhead/wasm/Cargo.toml
+++ b/pocs/wasm-overhead/wasm/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition = "2024"
+name = "wasm-overhead-wasm"
+version = "0.1.0"
+
+[dependencies]
+futures = "0.3.31"
+futures-executor = "0.3.31"
+tokio = {version = "1.44.1", features = [
+  # All allowed tokio features
+  "sync",
+  "macros",
+  "io-util",
+  "rt",
+  "time",
+]}
+wasi = "0.14.2"
+
+paxos-wasm-utils = {path = "../../../paxos-wasm/shared/utils"}
+wit-bindgen = "0.41"

--- a/pocs/wasm-overhead/wasm/src/main.rs
+++ b/pocs/wasm-overhead/wasm/src/main.rs
@@ -1,0 +1,317 @@
+pub mod bindings {
+    wit_bindgen::generate!({
+        path: "/home/roglaend/MASTER-DISASTER/wasm-master/paxos-wasm/shared/wit",
+        world: "wasm-overhead-world",
+    });
+}
+
+use bindings::paxos::default::network_types::NetworkMessage;
+use bindings::paxos::default::paxos_types::Node;
+use bindings::paxos::default::{
+    network_types::{Benchmark, MessagePayload},
+    paxos_types,
+};
+
+use bindings::paxos::default::{network_client, network_server};
+
+use std::env;
+use std::thread::sleep;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn current_time_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_micros() as u64
+}
+
+fn dummy_payload() -> String {
+    "HELLO WORLD".to_string()
+}
+
+fn run_latency_test() {
+    const MESSAGES_PER_BATCH: usize = 10;
+    const BATCHES: usize = 100;
+    const INTERVAL_BETWEEN_BATCHES_MS: u64 = 100;
+
+    {
+        let mut server = Some(network_server::NetworkServerResource::new());
+        let mut client = Some(network_client::NetworkClientResource::new());
+
+        if let Some(s) = server.as_mut() {
+            s.setup_listener("127.0.0.1:9000");
+        }
+
+        // let mut client = network_client::NetworkClientResource::new();
+
+        let node = Node {
+            node_id: 1,
+            address: "127.0.0.1:9001".to_string(), // address of Node B
+            role: paxos_types::PaxosRole::Proposer,
+        };
+
+        let mut rtt_samples = vec![];
+
+        for batch in 0..BATCHES {
+            // 1. Send 10 messages
+            let mut sent_timestamps = vec![];
+
+            for _ in 0..MESSAGES_PER_BATCH {
+                let now = current_time_micros();
+
+                let pay = Benchmark {
+                    send_timestamp: now,
+                    payload: dummy_payload(),
+                };
+
+                let msg = NetworkMessage {
+                    sender: node.clone(),
+                    payload: MessagePayload::Benchmark(pay),
+                };
+
+                sent_timestamps.push(now);
+                if let Some(c) = client.as_mut() {
+                    c.send_message_forget(&vec![node.clone()], &msg);
+                }
+            }
+
+            let mut received = 0;
+            let start_wait = std::time::Instant::now();
+            while start_wait.elapsed() < Duration::from_millis(50) {
+                if let Some(s) = server.as_mut() {
+                    let messages = s.get_messages();
+                    for msg in messages {
+                        match msg.payload {
+                            MessagePayload::Benchmark(pay) => {
+                                let rtt = current_time_micros() - pay.send_timestamp;
+                                rtt_samples.push(rtt);
+                                received += 1;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                sleep(Duration::from_millis(1));
+            }
+
+            println!("[Batch {}] Received {} responses", batch + 1, received);
+            sleep(Duration::from_millis(INTERVAL_BETWEEN_BATCHES_MS));
+        }
+
+        println!("\n=== RTT Results ===");
+        for (i, rtt) in rtt_samples.iter().enumerate() {
+            println!("Message {}: RTT = {} μs", i + 1, rtt);
+        }
+
+        let avg = rtt_samples.iter().sum::<u64>() as f64 / rtt_samples.len() as f64;
+        println!("Average RTT: {:.2} μs", avg);
+
+        drop(client.take());
+        drop(server.take());
+    }
+}
+
+pub fn run_throughput_test() {
+    use std::time::Instant;
+
+    const TEST_DURATION_SECS: u64 = 5;
+    const MAX_REQUESTS: usize = 1000;
+
+    let mut server = Some(network_server::NetworkServerResource::new());
+    let mut client = Some(network_client::NetworkClientResource::new());
+
+    server.as_mut().unwrap().setup_listener("127.0.0.1:9000");
+
+    let node = Node {
+        node_id: 1,
+        address: "127.0.0.1:9001".to_string(), // responder address
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    let mut sent = 0;
+    let mut received = 0;
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(TEST_DURATION_SECS);
+    // Send all messages
+    while Instant::now() < deadline {
+        if sent < MAX_REQUESTS {
+            let msg = NetworkMessage {
+                sender: node.clone(),
+                payload: MessagePayload::Benchmark(Benchmark {
+                    send_timestamp: 0, // unused here
+                    payload: dummy_payload(),
+                }),
+            };
+            client
+                .as_mut()
+                .unwrap()
+                .send_message_forget(&vec![node.clone()], &msg);
+            sent += 1;
+        }
+
+        let messages = server.as_mut().unwrap().get_messages();
+        for msg in messages {
+            if let MessagePayload::Benchmark(_) = msg.payload {
+                received += 1;
+            }
+        }
+        if received >= sent {
+            break;
+        }
+    }
+
+    // Wait for all responses (or timeout)
+    let drain_end = Instant::now() + Duration::from_millis(1000);
+    while Instant::now() < drain_end && received < sent {
+        let messages = server.as_mut().unwrap().get_messages();
+        for msg in messages {
+            if let MessagePayload::Benchmark(_) = msg.payload {
+                received += 1;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(1));
+    }
+
+    let duration = Instant::now().duration_since(start).as_secs_f64();
+    let throughput = received as f64 / duration;
+
+    println!("\n=== Time-Based Throughput Test Results ===");
+    println!("Duration:  {:.2} seconds", duration);
+    println!("Sent:      {}", sent);
+    println!("Received:  {}", received);
+    println!("Throughput: {:.2} messages/sec", throughput);
+
+    // Still gets resource has children error
+    drop(client.take());
+    drop(server.take());
+}
+
+pub fn run_latency_rtt_isolated() {
+    const TOTAL_MESSAGES: usize = 1000;
+    const RESPONSE_TIMEOUT_MS: u64 = 100;
+
+    let mut server = Some(network_server::NetworkServerResource::new());
+    let mut client = Some(network_client::NetworkClientResource::new());
+
+    server.as_mut().unwrap().setup_listener("127.0.0.1:9000");
+
+    let node = Node {
+        node_id: 1,
+        address: "127.0.0.1:9001".to_string(), // address of echo responder
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    let mut rtt_samples = vec![];
+
+    for i in 0..TOTAL_MESSAGES {
+        let msg = NetworkMessage {
+            sender: node.clone(),
+            payload: MessagePayload::Benchmark(Benchmark {
+                send_timestamp: 0, // unused
+                payload: dummy_payload(),
+            }),
+        };
+
+        let start = std::time::Instant::now();
+        client
+            .as_mut()
+            .unwrap()
+            .send_message_forget(&vec![node.clone()], &msg);
+
+        // Wait for the echo
+        let timeout = std::time::Instant::now() + Duration::from_millis(RESPONSE_TIMEOUT_MS);
+        loop {
+            let messages = server.as_mut().unwrap().get_messages();
+            if let Some(_) = messages
+                .into_iter()
+                .find(|m| matches!(m.payload, MessagePayload::Benchmark(_)))
+            {
+                let rtt = start.elapsed().as_micros();
+                rtt_samples.push(rtt);
+                println!("Message {}: RTT = {} μs", i + 1, rtt);
+                break;
+            }
+
+            if std::time::Instant::now() >= timeout {
+                println!("Message {}: Timed out", i + 1);
+                break;
+            }
+
+            std::thread::sleep(Duration::from_micros(100));
+        }
+    }
+
+    let avg = rtt_samples.iter().sum::<u128>() as f64 / rtt_samples.len().max(1) as f64;
+    println!("\n=== Isolated RTT Results ===");
+    println!("Samples: {}", rtt_samples.len());
+    println!("Average RTT: {:.2} μs", avg);
+
+    drop(client.take());
+    drop(server.take());
+}
+
+pub fn run_echo_responder() {
+    let mut server = network_server::NetworkServerResource::new();
+    server.setup_listener("127.0.0.1:9001"); // Responder listens here
+
+    let mut client = network_client::NetworkClientResource::new();
+
+    let target = Node {
+        node_id: 0,
+        address: "127.0.0.1:9000".to_string(), // Echo back to client
+        role: paxos_types::PaxosRole::Proposer,
+    };
+
+    println!("[Responder] Listening on 127.0.0.1:9001");
+
+    loop {
+        let messages = server.get_messages();
+        for msg in messages {
+            if let MessagePayload::Benchmark(benchmark_msg) = msg.payload {
+                // let _ = fib(35); // Simulate some work
+                let response = NetworkMessage {
+                    sender: target.clone(), // This field is ignored by client
+                    payload: MessagePayload::Benchmark(benchmark_msg), // Echo unchanged
+                };
+
+                client.send_message_forget(&vec![target.clone()], &response);
+            }
+        }
+
+        sleep(Duration::from_millis(1)); // Prevent busy loop
+    }
+}
+
+fn fib(n: u64) -> u64 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fib(n - 1) + fib(n - 2),
+    }
+}
+
+fn main() -> () {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        eprintln!("Usage: {} <mode>", args[0]);
+        eprintln!("  0 = run_echo_responder");
+        eprintln!("  1 = run_latency_test");
+        eprintln!("  2 = run_throughput_test");
+        eprintln!("  3 = run_latency_rtt_isolated");
+        std::process::exit(1);
+    }
+
+    match args[1].as_str() {
+        "0" => run_echo_responder(),
+        "1" => run_latency_test(),
+        "2" => run_throughput_test(),
+        "3" => run_latency_rtt_isolated(),
+        _ => {
+            eprintln!(
+                "Invalid mode '{}'. Use 0 = latency, 1 = responder, 2 = throughput.",
+                args[1]
+            );
+            std::process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Implemetasjon av nettverks components i native rust

Brukt for testing av simpel tcp system native vs component

Kan og bli brukt som host implementation av network-server og tcp-client i full system
(må fjerna plugs av network_server inn i runner og tcp-client inn i agents for det ovenfor)

Running notes:
Klarte ikkje fiksa build script for component som ligge i pocs:

cd pocs/wasm-overhead/wasm/ && cargo build --release --target wasm32-wasip2

cargo build i root for å plugga server og client inn i wasm_overhead_compoennt

For echo node wasm:
wasmtime run -S inherit-network=y target/wasm32-wasip2/release/composed_wasm_overhead.wasm 0

For test node wasm: 
wasmtime run -S inherit-network=y target/wasm32-wasip2/release/composed_wasm_overhead.wasm 1eller2eller3 (latency-variant, tp, latency-variant) 


For echo node native:

./target/release/wasm-overhead-native 0

For test node native:

./target/release/wasm-overhead-native 1eller2eller3

