### PR TITLE
Paxos_wasmtime fix with cluster support

### DIFF
--- a/paxos-wasm/modular-ws/src/paxos_wasm.rs
+++ b/paxos-wasm/modular-ws/src/paxos_wasm.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use wasmtime::component::{Component, Linker, ResourceAny};
-use wasmtime::{Config, Engine, ProfilingStrategy, Store};
+use wasmtime::{Config, Engine, Store};
 use wasmtime_wasi::{
     DirPerms, FilePerms, IoView, ResourceTable, WasiCtx, WasiCtxBuilder, WasiView,
 };

--- a/paxos-wasm/runner-ws/Cargo.toml
+++ b/paxos-wasm/runner-ws/Cargo.toml
@@ -15,6 +15,7 @@ tracing-subscriber = {version = "0.3", features = ["env-filter"]}
 wasmtime = "31"
 wasmtime-wasi = "31"
 yaml-rust = "0.4"
+anyhow = "1"
 
 [build-dependencies]
 agents = {path = "../agents"}

--- a/paxos-wasm/runner-ws/src/config.rs
+++ b/paxos-wasm/runner-ws/src/config.rs
@@ -1,72 +1,95 @@
-use std::{fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 use yaml_rust::YamlLoader;
 
 use crate::bindings::paxos::default::{
     logger::Level,
-    network_types::PaxosRole,
-    paxos_types::{Node, RunConfig},
+    paxos_types::{Node, PaxosRole, RunConfig},
 };
 
 pub struct Config {
-    pub node: Node,
-    pub remote_nodes: Vec<Node>,
-    pub is_leader: bool,
+    /// all nodes from the config
+    pub all_nodes: Vec<Node>,
+
+    /// the subset that belongs to this cluster
+    pub cluster_nodes: Vec<Node>,
+
+    /// highest node_id across all nodes
+    pub leader_id: u64,
+
     pub run_config: RunConfig,
     pub log_level: Level,
 }
 
 impl Config {
-    pub fn load<P: AsRef<Path>>(path: P, this_id: u64) -> Self {
-        let s = fs::read_to_string(&path).expect("read config");
-        let docs = YamlLoader::load_from_str(&s).unwrap();
+    pub fn load<P: AsRef<Path>>(path: P, cluster_id: u64) -> anyhow::Result<Self> {
+        let s = fs::read_to_string(path)?;
+        let docs = YamlLoader::load_from_str(&s)?;
         let doc = &docs[0];
 
-        let raw = doc["nodes"].as_vec().unwrap();
-
-        // Get the log level
-        let level_str = doc["log_level"].as_str().unwrap_or("info").to_lowercase();
-        let log_level = match level_str.as_str() {
+        // parse log level
+        let log_level = match doc["log_level"].as_str().unwrap_or("info") {
             "debug" => Level::Debug,
             "info" => Level::Info,
             "warning" => Level::Warn,
             "error" => Level::Error,
-            other => panic!("unknown log_level `{}`", other),
+            o => anyhow::bail!("bad log_level `{}`", o),
         };
 
-        // Build all nodes
-        let nodes: Vec<Node> = raw
+        // parse all nodes
+        let all_nodes: Vec<Node> = doc["nodes"]
+            .as_vec()
+            .unwrap()
             .iter()
-            .map(|e| {
-                let id = e["node_id"].as_i64().unwrap() as u64;
-                let pax = e["address"].as_str().unwrap().to_string();
-                let role = match e["role"].as_str().unwrap() {
+            .map(|n| {
+                let id = n["node_id"].as_i64().unwrap() as u64;
+                let addr = n["address"].as_str().unwrap().to_string();
+                let role = match n["role"].as_str().unwrap() {
                     "proposer" => PaxosRole::Proposer,
                     "acceptor" => PaxosRole::Acceptor,
                     "learner" => PaxosRole::Learner,
                     "coordinator" => PaxosRole::Coordinator,
-                    other => panic!("invalid role `{}`", other),
+                    other => panic!("bad role `{}`", other),
                 };
                 Node {
                     node_id: id,
-                    address: pax,
+                    address: addr,
                     role,
                 }
             })
             .collect();
 
-        // Determine leader = highest node_id
-        let leader_id = nodes.iter().map(|n| n.node_id).max().unwrap();
-
-        // Split out this node + remotes
-        let is_leader = this_id == leader_id;
-        let node = nodes
+        let leader_id = all_nodes
             .iter()
-            .find(|n| n.node_id == this_id)
-            .unwrap_or_else(|| panic!("node_id {} missing", this_id))
-            .clone();
-        let remote_nodes = nodes.into_iter().filter(|n| n.node_id != this_id).collect();
+            .map(|n| n.node_id)
+            .max()
+            .expect("must have at least one node");
 
-        // Parse run_config
+        // parse clusters → map<u64, list<u64>>
+        let mut clusters = HashMap::new();
+        for (k, y) in doc["clusters"].as_hash().unwrap().iter() {
+            let cluster_id = k.as_i64().unwrap() as u64;
+            let node_ids: Vec<u64> = y
+                .as_vec()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_i64().unwrap() as u64)
+                .collect();
+            clusters.insert(cluster_id, node_ids);
+        }
+
+        // look up this cluster
+        let node_ids = clusters
+            .get(&cluster_id)
+            .ok_or_else(|| anyhow::anyhow!("no cluster {} in config", cluster_id))?;
+
+        // filter the global node list
+        let cluster_nodes: Vec<_> = all_nodes
+            .clone()
+            .into_iter()
+            .filter(|n| node_ids.contains(&n.node_id))
+            .collect();
+
+        // parse run_config block
         let r = &doc["run_config"];
         let run_config = RunConfig {
             is_event_driven: r["is_event_driven"].as_bool().unwrap(),
@@ -82,15 +105,15 @@ impl Config {
             learn_max_gap: r["learn_max_gap"].as_i64().unwrap() as u64,
             executed_batch_size: r["executed_batch_size"].as_i64().unwrap() as u64,
             client_server_port: r["client_server_port"].as_i64().unwrap() as u16,
-            persistent_storage: r["persistent_storage"].as_bool().unwrap(), 
+            persistent_storage: r["persistent_storage"].as_bool().unwrap(),
         };
 
-        Config {
-            node,
-            remote_nodes,
-            is_leader,
+        Ok(Config {
+            all_nodes,
+            cluster_nodes,
+            leader_id,
             run_config,
             log_level,
-        }
+        })
     }
 }

--- a/paxos-wasm/runner-ws/src/config.yaml
+++ b/paxos-wasm/runner-ws/src/config.yaml
@@ -1,60 +1,57 @@
-# ─── Local Paxos Cluster ───────────────────────────
-log_level: warning # "debug", "info", "warning", "error"
+# ─── config.yaml ────────────────────────────────────────
 
-# full list of nodes and which paxos-role they have
+# logging
+log_level: warning   # "debug", "info", "warning", "error"
+
+# all nodes in your entire deployment:
 nodes:
   - node_id: 1
     address: "127.0.0.1:50051"
     role: "learner"
   - node_id: 2
     address: "127.0.0.1:50052"
-    role: "learner"
+    role: "acceptor"
   - node_id: 3
     address: "127.0.0.1:50053"
-    role: "acceptor"
+    role: "proposer"
+
   - node_id: 4
     address: "127.0.0.1:50054"
-    role: "acceptor"
+    role: "learner"
   - node_id: 5
     address: "127.0.0.1:50055"
     role: "acceptor"
   - node_id: 6
     address: "127.0.0.1:50056"
     role: "proposer"
+
   - node_id: 7
     address: "127.0.0.1:50057"
-    role: "proposer" # Last node has to be either "proposer" or "coordinator"
+    role: "learner"
+  - node_id: 8
+    address: "127.0.0.1:50058"
+    role: "acceptor"
+  - node_id: 9
+    address: "127.0.0.1:50059"
+    role: "proposer"
 
+# how those nodes are grouped into independent Paxos clusters
+clusters:
+  1: [1,2,3]
 
-# # ─── cluster settings ────────────────────────────────── same runtime
-# nodes:
-#   - node_id: 1
-#     address: "127.0.0.1:50051"
-#     role: "learner"
-#   - node_id: 2
-#     address: "127.0.0.1:50052"
-#     role: "acceptor"
-#   - node_id: 3
-#     address: "127.0.0.1:50053"
-#     role: "proposer"
-#   - node_id: 4
-#     address: "127.0.0.1:50054"
-#     role: "learner"
-#   - node_id: 5
-#     address: "127.0.0.1:50055"
-#     role: "acceptor"
-#   - node_id: 6
-#     address: "127.0.0.1:50056"
-#     role: "proposer"
-#   - node_id: 7
-#     address: "127.0.0.1:50057"
-#     role: "learner"
-#   - node_id: 8
-#     address: "127.0.0.1:50058"
-#     role: "acceptor"
-#   - node_id: 9
-#     address: "127.0.0.1:50059"
-#     role: "proposer"
+  2: [4,5,6]
+
+  3: [7,8,9]
+
+  # 1: [1]
+  # 2: [2]
+  # 3: [3]
+  # 4: [4]
+  # 5: [5]
+  # 6: [6]
+  # 7: [7]
+  # 8: [8]
+  # 9: [9]
 
 # ─── run-loop tuning ───────────────────────────────────
 run_config:
@@ -72,3 +69,9 @@ run_config:
   executed_batch_size: 10
   client_server_port: 60000
   persistent_storage: false
+  crash:
+    - node: 3
+    - slot: 12939
+  graceful:
+    - node: 7
+    - slot: 223745

--- a/paxos-wasm/runner-ws/src/config.yaml
+++ b/paxos-wasm/runner-ws/src/config.yaml
@@ -60,7 +60,7 @@ run_config:
   learners_send_executed: true
   prepare_timeout: 1000
   demo_client: true
-  demo_client_requests: 100000
+  demo_client_requests: 100
   batch_size: 100
   tick_micros: 100
   exec_interval_ms: 100

--- a/paxos-wasm/runner-ws/src/paxos_wasm.rs
+++ b/paxos-wasm/runner-ws/src/paxos_wasm.rs
@@ -78,7 +78,6 @@ impl ComponentRunStates {
 }
 
 pub struct PaxosWasmtime {
-    // pub _engine: Engine,
     pub store: Mutex<Store<ComponentRunStates>>,
     pub bindings: bindings::PaxosRunnerWorld,
     pub resource_handle: ResourceAny,
@@ -93,10 +92,6 @@ impl PaxosWasmtime {
         run_config: RunConfig,
         log_level: Level,
     ) -> Result<Self, Box<dyn Error>> {
-        // let mut config = wasmtime::Config::default();
-        // config.async_support(true);
-        // let engine = Engine::new(&config)?;
-
         let state = ComponentRunStates::new(node.clone(), log_level);
         let mut store = Store::new(&engine, state);
         let mut linker = Linker::<ComponentRunStates>::new(&engine);
@@ -129,7 +124,6 @@ impl PaxosWasmtime {
             .await?;
 
         Ok(Self {
-            // _engine: engine,
             store: Mutex::new(store),
             bindings: final_bindings,
             resource_handle,

--- a/paxos-wasm/runner-ws/src/run.rs
+++ b/paxos-wasm/runner-ws/src/run.rs
@@ -26,14 +26,22 @@ pub async fn run_cluster(
         } else {
             "Node"
         };
-        error!("  • Node {} @{} ({})", n.node_id, n.address, role,);
+        error!(
+            "  • Node {} @{} ({:?} {})",
+            n.node_id, n.address, n.role, role,
+        );
     }
 
     // spawn one async task per node in the cluster
     let mut tasks = Vec::new();
     for node in cfg.cluster_nodes.iter().cloned() {
         let engine = engine.clone();
-        let all_nodes = cfg.all_nodes.clone();
+        let all_nodes: Vec<_> = cfg
+            .all_nodes
+            .clone()
+            .into_iter()
+            .filter(|n| n.node_id != node.node_id)
+            .collect();
         let is_leader = node.node_id == cfg.leader_id;
         let run_config = cfg.run_config.clone();
         let log_level = cfg.log_level;

--- a/paxos-wasm/runner-ws/src/run.rs
+++ b/paxos-wasm/runner-ws/src/run.rs
@@ -1,106 +1,70 @@
-use std::{error::Error, sync::Arc, thread};
-use tokio::runtime::Runtime;
-use tracing::info;
+use crate::config::Config;
+use crate::host_logger;
+use crate::paxos_wasm::PaxosWasmtime;
+use futures::future::join_all;
+use tokio::signal;
+use tracing::error;
 use wasmtime::Engine;
 
-use crate::{config::Config, host_logger, paxos_wasm::PaxosWasmtime};
-
-pub async fn run_standalone(
-    node_id: u64,
-    config: String,
+pub async fn run_cluster(
+    cluster_id: u64,
+    config_path: &str,
     engine: &Engine,
-) -> Result<(), Box<dyn Error>> {
-    let cfg = Config::load(config, node_id);
-    info!(
-        "Node {} @{} role={:?} is_leader={}",
-        cfg.node.node_id, cfg.node.address, cfg.node.role, cfg.is_leader,
-    );
-
+) -> anyhow::Result<()> {
+    let cfg = Config::load(config_path, cluster_id)?;
     host_logger::init_tracing_with(cfg.log_level);
 
-    let paxos = PaxosWasmtime::new(
-        engine,
-        cfg.node.clone(),
-        cfg.remote_nodes.clone(),
-        cfg.is_leader,
-        cfg.run_config.clone(),
-        cfg.log_level,
-    )
-    .await?;
-
-    let mut store = paxos.store.lock().await;
-    paxos
-        .resource()
-        .call_run(&mut *store, paxos.resource_handle.clone())
-        .await?;
-
-    Ok(())
-}
-
-pub async fn run_same_runtime(
-    base_node_id: u64,
-    config: String,
-    engine: &Engine,
-) -> Result<(), Box<dyn Error>> {
-    let mut tasks = vec![];
-
-    for offset in 0..3 {
-        let node_id = base_node_id + offset;
-        let engine = engine.clone(); // Clone the Arc for thread safety
-        let config = config.clone(); // Clone the config string
-
-        // Spawn a new Tokio task to spawn a thread for each node
-        let task = tokio::spawn(async move {
-            let cfg = Config::load(config, node_id);
-            info!(
-                "Node {} @{} role={:?} is_leader={}",
-                cfg.node.node_id, cfg.node.address, cfg.node.role, cfg.is_leader,
-            );
-
-            host_logger::init_tracing_with(cfg.log_level);
-
-            let paxos_wasmtime = Arc::new(
-                PaxosWasmtime::new(
-                    &engine,
-                    cfg.node.clone(),
-                    cfg.remote_nodes.clone(),
-                    cfg.is_leader,
-                    cfg.run_config.clone(),
-                    cfg.log_level,
-                )
-                .await
-                .expect("Failed to initialize PaxosWasmtime"),
-            );
-
-            // Offload the async code to a separate OS thread using a Tokio runtime in that thread
-            let paxos_wasmtime_clone = paxos_wasmtime.clone();
-            thread::spawn(move || {
-                // Create a new Tokio runtime in the OS thread
-                let rt = Runtime::new().expect("Failed to create Tokio runtime");
-
-                // Run the async `call_run` within the Tokio runtime in the OS thread
-                rt.block_on(async {
-                    let mut guard = paxos_wasmtime_clone.store.lock().await;
-                    let store_ctx = &mut *guard;
-
-                    let resource = paxos_wasmtime_clone.resource();
-
-                    // Directly call the infinite `call_run` method without an additional loop
-                    resource
-                        .call_run(store_ctx, paxos_wasmtime_clone.resource_handle.clone())
-                        .await
-                        .expect("Failed to call run");
-                });
-            });
-        });
-
-        tasks.push(task);
+    error!(
+        "Cluster {}: {} nodes, leader={}",
+        cluster_id,
+        cfg.cluster_nodes.len(),
+        cfg.leader_id,
+    );
+    for n in &cfg.cluster_nodes {
+        let role = if n.node_id == cfg.leader_id {
+            "Leader"
+        } else {
+            "Node"
+        };
+        error!("  • Node {} @{} ({})", n.node_id, n.address, role,);
     }
 
-    // Wait for all tasks to be spawned (but they will run indefinitely)
-    futures::future::join_all(tasks).await;
+    // spawn one async task per node in the cluster
+    let mut tasks = Vec::new();
+    for node in cfg.cluster_nodes.iter().cloned() {
+        let engine = engine.clone();
+        let all_nodes = cfg.all_nodes.clone();
+        let is_leader = node.node_id == cfg.leader_id;
+        let run_config = cfg.run_config.clone();
+        let log_level = cfg.log_level;
 
-    // Wait for a SIGINT (Ctrl+C) to gracefully shutdown the program
-    tokio::signal::ctrl_c().await?; // Wait for SIGINT (Ctrl+C)
+        tasks.push(tokio::spawn(async move {
+            let paxos = PaxosWasmtime::new(
+                &engine,
+                node.clone(),
+                all_nodes,
+                is_leader,
+                run_config.clone(),
+                log_level,
+            )
+            .await
+            .expect("failed to instantiate Wasm");
+
+            // this future never returns until Stop, it drives the Paxos loop
+            let mut store = paxos.store.lock().await;
+            paxos
+                .resource()
+                .call_run(&mut *store, paxos.resource_handle.clone())
+                .await
+                .expect("Wasm run()");
+        }));
+    }
+
+    // wait for all the Wasm‐hosts to start, runs forever
+    join_all(tasks).await;
+
+    // and also listen for Ctrl-C so we can shut down gracefully
+    signal::ctrl_c().await?;
+
     Ok(())
 }

--- a/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
+++ b/paxos-wasm/runners/paxos-coordinator/src/coordinator.rs
@@ -29,23 +29,55 @@ impl Guest for MyCoordinator {
     type PaxosCoordinatorResource = MyPaxosCoordinatorResource;
 }
 
+enum Agents {
+    Proposer(Arc<proposer_agent::ProposerAgentResource>),
+    Acceptor(Arc<acceptor_agent::AcceptorAgentResource>),
+    Learner(Arc<learner_agent::LearnerAgentResource>),
+    Coordinator {
+        proposer: Arc<proposer_agent::ProposerAgentResource>,
+        acceptor: Arc<acceptor_agent::AcceptorAgentResource>,
+        learner: Arc<learner_agent::LearnerAgentResource>,
+    },
+}
+
 pub struct MyPaxosCoordinatorResource {
     config: RunConfig,
 
     node: Node,
     nodes: Vec<Node>,
 
-    // Uses the agents
-    proposer_agent: Arc<proposer_agent::ProposerAgentResource>,
-    acceptor_agent: Arc<acceptor_agent::AcceptorAgentResource>,
-    learner_agent: Arc<learner_agent::LearnerAgentResource>,
+    agents: Agents,
 
     failure_detector: Arc<failure_detector::FailureDetectorResource>,
 }
 
 impl MyPaxosCoordinatorResource {
+    fn proposer(&self) -> &proposer_agent::ProposerAgentResource {
+        match &self.agents {
+            Agents::Proposer(p) => &*p,
+            Agents::Coordinator { proposer, .. } => &*proposer,
+            _ => panic!("Tried to use proposer on a non-proposer node"),
+        }
+    }
+
+    fn acceptor(&self) -> &acceptor_agent::AcceptorAgentResource {
+        match &self.agents {
+            Agents::Acceptor(a) => &*a,
+            Agents::Coordinator { acceptor, .. } => &*acceptor,
+            _ => panic!("Tried to use acceptor on a non-acceptor node"),
+        }
+    }
+
+    fn learner(&self) -> &learner_agent::LearnerAgentResource {
+        match &self.agents {
+            Agents::Learner(l) => &*l,
+            Agents::Coordinator { learner, .. } => &*learner,
+            _ => panic!("Tried to use learner on a non-learner node"),
+        }
+    }
+
     fn maybe_retry_learn(&self) {
-        match self.learner_agent.evaluate_retry() {
+        match self.learner().evaluate_retry() {
             RetryLearnResult::NoGap => return,
             RetryLearnResult::Skip(slot) => {
                 logger::log_debug(&format!(
@@ -60,22 +92,22 @@ impl MyPaxosCoordinatorResource {
                     slot
                 ));
                 if self.config.acceptors_send_learns {
-                    self.acceptor_agent.retry_learn(slot); // TODO
+                    self.acceptor().retry_learn(slot); // TODO
                 } else {
-                    self.proposer_agent.retry_learn(slot);
+                    self.proposer().retry_learn(slot);
                 }
             }
         }
     }
 
     fn drive_learner(&self) {
-        self.learner_agent.execute_chosen_learns();
+        self.learner().execute_chosen_learns();
 
         // TODO: Might add a max batch or require a full batch, but don't think that's valid here.
-        let exec = self.learner_agent.collect_executed(None, false);
+        let exec = self.learner().collect_executed(None, false);
 
-        if self.proposer_agent.is_leader() && !exec.results.is_empty() {
-            let _ = self.proposer_agent.process_executed(&exec);
+        if self.proposer().is_leader() && !exec.results.is_empty() {
+            let _ = self.proposer().process_executed(&exec);
         }
     }
 }
@@ -83,17 +115,34 @@ impl MyPaxosCoordinatorResource {
 impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
     /// Creates a new coordinator resource.
     fn new(node: Node, nodes: Vec<Node>, is_leader: bool, config: RunConfig) -> Self {
-        // TODO: Only load the agents needed based on the role? Like we did in tcp server.
-        let proposer_agent = Arc::new(proposer_agent::ProposerAgentResource::new(
-            &node, &nodes, is_leader, config,
-        ));
-        let acceptor_agent = Arc::new(acceptor_agent::AcceptorAgentResource::new(
-            &node, &nodes, config,
-        ));
-
-        let learner_agent = Arc::new(learner_agent::LearnerAgentResource::new(
-            &node, &nodes, config,
-        ));
+        let agents = match node.role {
+            PaxosRole::Proposer => Agents::Proposer(Arc::new(
+                proposer_agent::ProposerAgentResource::new(&node, &nodes, is_leader, config),
+            )),
+            PaxosRole::Acceptor => Agents::Acceptor(Arc::new(
+                acceptor_agent::AcceptorAgentResource::new(&node, &nodes, config),
+            )),
+            PaxosRole::Learner => Agents::Learner(Arc::new(
+                learner_agent::LearnerAgentResource::new(&node, &nodes, config),
+            )),
+            PaxosRole::Coordinator => {
+                let proposer = Arc::new(proposer_agent::ProposerAgentResource::new(
+                    &node, &nodes, is_leader, config,
+                ));
+                let acceptor = Arc::new(acceptor_agent::AcceptorAgentResource::new(
+                    &node, &nodes, config,
+                ));
+                let learner = Arc::new(learner_agent::LearnerAgentResource::new(
+                    &node, &nodes, config,
+                ));
+                Agents::Coordinator {
+                    proposer,
+                    acceptor,
+                    learner,
+                }
+            }
+            PaxosRole::Client => unreachable!(),
+        };
 
         let failure_delta = 10; // TODO: Make this dynamic
         let failure_detector = Arc::new(failure_detector::FailureDetectorResource::new(
@@ -106,52 +155,59 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
             config,
             node,
             nodes,
-            proposer_agent,
-            acceptor_agent,
-            learner_agent,
+            agents,
             failure_detector,
         }
     }
 
     fn submit_client_request(&self, req: Value) -> bool {
-        self.proposer_agent.submit_client_request(&req)
+        match &self.agents {
+            Agents::Proposer(p) | Agents::Coordinator { proposer: p, .. } => {
+                p.submit_client_request(&req)
+            }
+            _ => false,
+        }
     }
 
     fn is_leader(&self) -> bool {
-        self.proposer_agent.is_leader()
+        match &self.agents {
+            Agents::Proposer(p) | Agents::Coordinator { proposer: p, .. } => p.is_leader(),
+            _ => false,
+        }
     }
 
     // Ticker called from runner
     fn run_paxos_loop(&self) -> Option<Vec<ClientResponse>> {
-        match self.node.role {
-            PaxosRole::Client => {
-                panic!("[Coordinator] Client nodes should never call run_paxos_loop");
+        match &self.agents {
+            Agents::Proposer(prop) => {
+                return prop.run_paxos_loop();
             }
 
-            PaxosRole::Proposer => self.proposer_agent.run_paxos_loop(),
-
-            PaxosRole::Acceptor => {
-                // self.acceptor_agent.run_paxos_loop(); // TODO
-                None
+            Agents::Acceptor(acc) => {
+                // acc.run_paxos_loop(); // TODO: ?
+                return None;
             }
 
-            PaxosRole::Learner => {
-                self.learner_agent.run_paxos_loop();
-                None
+            Agents::Learner(lea) => {
+                lea.run_paxos_loop();
+                return None;
             }
 
-            PaxosRole::Coordinator => {
+            Agents::Coordinator {
+                proposer,
+                acceptor,
+                learner,
+            } => {
                 self.maybe_retry_learn();
                 self.drive_learner();
 
-                // only the leader runs proposer phases
-                if !self.proposer_agent.is_leader() {
+                if !proposer.is_leader() {
                     return None;
                 }
 
-                match self.proposer_agent.get_paxos_phase() {
+                match proposer.get_paxos_phase() {
                     PaxosPhase::Start => {
-                        self.proposer_agent.start_leader_loop();
+                        proposer.start_leader_loop();
                         None
                     }
                     PaxosPhase::PrepareSend => {
@@ -159,7 +215,7 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
                         None
                     }
                     PaxosPhase::PreparePending => {
-                        self.proposer_agent.check_prepare_timeout();
+                        proposer.check_prepare_timeout();
                         None
                     }
                     PaxosPhase::AcceptCommit => {
@@ -176,11 +232,11 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
     /// The coordinator queries its local acceptor for a promise and passes it along.
     fn prepare_phase(&self) -> PrepareResult {
         // Starts from 1, or the adu on the learner, the highest slot the learner has chosen.
-        let slot = self.learner_agent.get_adu() + 1;
-        let ballot = self.proposer_agent.get_current_ballot();
+        let slot = self.learner().get_adu() + 1;
+        let ballot = self.proposer().get_current_ballot();
 
         // Query local acceptor.
-        let local_promise_result = self.acceptor_agent.process_prepare(slot, ballot);
+        let local_promise_result = self.acceptor().process_prepare(slot, ballot);
 
         let local_promise = match local_promise_result {
             PromiseResult::Promised(promise) => promise,
@@ -195,7 +251,7 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
 
         // Merge the local promise with remote responses using the proposer agent.
         let prepare_result = self
-            .proposer_agent
+            .proposer()
             .prepare_phase(slot, ballot, &vec![local_promise]);
 
         logger::log_info(&format!(
@@ -206,7 +262,7 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
     }
 
     fn accept_phase(&self) -> AcceptResult {
-        let props = self.proposer_agent.proposals_to_accept();
+        let props = self.proposer().proposals_to_accept();
 
         if props.is_empty() {
             logger::log_debug("[Coordinator] Accept phase aborted: no proposal available.");
@@ -215,27 +271,23 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
 
         // For each proposal, do a local accept first then make proposer send accept messages to rest.
         for p in props {
-            let local_acc = self
-                .acceptor_agent
-                .process_accept(p.slot, p.ballot, &p.value);
+            let local_acc = self.acceptor().process_accept(p.slot, p.ballot, &p.value);
 
             match local_acc {
                 AcceptedResult::Accepted(acc) => {
                     // Sends Accept to all acceptors
                     let accept_result =
-                        self.proposer_agent
+                        self.proposer()
                             .accept_phase(&p.value, p.slot, p.ballot, &vec![acc]);
 
                     if self.config.acceptors_send_learns {
                         if let Some(learn) =
                             // Sends Learn to all learners
-                            self.acceptor_agent.commit_phase(p.slot, &p.value.clone())
+                            self.acceptor().commit_phase(p.slot, &p.value.clone())
                         {
-                            let _ = self.learner_agent.record_learn(
-                                learn.slot,
-                                &learn.value,
-                                &self.node,
-                            );
+                            let _ =
+                                self.learner()
+                                    .record_learn(learn.slot, &learn.value, &self.node);
                         }
                     }
 
@@ -267,17 +319,17 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
 
     fn commit_phase(&self) -> Option<Vec<ClientResponse>> {
         if !self.config.acceptors_send_learns {
-            let to_commit = self.proposer_agent.learns_to_commit();
+            let to_commit = self.proposer().learns_to_commit();
             if !to_commit.is_empty() {
                 for learn in to_commit {
-                    self.proposer_agent.broadcast_learn(&learn);
-                    self.learner_agent
+                    self.proposer().broadcast_learn(&learn);
+                    self.learner()
                         .record_learn(learn.slot, &learn.value, &self.node);
                 }
             }
         }
 
-        let responses = self.proposer_agent.collect_client_responses();
+        let responses = self.proposer().collect_client_responses();
         (!responses.is_empty()).then(|| {
             logger::log_info(&format!(
                 "[Coordinator] Sending {} client responses",
@@ -297,61 +349,99 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
             sender: self.node.clone(),
             payload: MessagePayload::Ignore,
         };
-        match message.payload {
+        match &self.agents {
             //* Forward the relevant messages to the respective agents */
-            MessagePayload::Promise(_) => self.proposer_agent.handle_message(&message),
-            MessagePayload::Accepted(_) => self.proposer_agent.handle_message(&message),
-
-            MessagePayload::RetryLearn(_) => {
-                if !self.config.acceptors_send_learns {
-                    self.proposer_agent.handle_message(&message)
-                } else {
-                    self.acceptor_agent.handle_message(&message)
+            Agents::Proposer(proposer) => match message.payload {
+                MessagePayload::Promise(_) => proposer.handle_message(&message),
+                MessagePayload::Accepted(_) => proposer.handle_message(&message),
+                MessagePayload::RetryLearn(_) => {
+                    if !self.config.acceptors_send_learns {
+                        proposer.handle_message(&message)
+                    } else {
+                        ignore_msg
+                    }
                 }
-            }
+                MessagePayload::Executed(_) => proposer.handle_message(&message),
+                _ => ignore_msg,
+            },
 
-            MessagePayload::Executed(_) => {
-                if self.node.role != PaxosRole::Coordinator {
-                    self.proposer_agent.handle_message(&message);
+            Agents::Acceptor(acceptor) => match message.payload {
+                MessagePayload::Prepare(_) => acceptor.handle_message(&message),
+                MessagePayload::Accept(_) => acceptor.handle_message(&message),
+                MessagePayload::RetryLearn(_) => {
+                    if self.config.acceptors_send_learns {
+                        acceptor.handle_message(&message)
+                    } else {
+                        ignore_msg
+                    }
                 }
-                //* Not needed by non-leader coordinators due to them having access to "adu" through their learners */
-                ignore_msg
-            }
+                _ => ignore_msg,
+            },
 
-            MessagePayload::Prepare(_) => self.acceptor_agent.handle_message(&message),
-            MessagePayload::Accept(_) => self.acceptor_agent.handle_message(&message),
+            Agents::Learner(learner) => match message.payload {
+                MessagePayload::Learn(_) => learner.handle_message(&message),
+                _ => ignore_msg,
+            },
 
-            MessagePayload::Learn(_) => self.learner_agent.handle_message(&message),
+            Agents::Coordinator {
+                proposer,
+                acceptor,
+                learner,
+            } => match message.payload {
+                MessagePayload::Promise(_) => proposer.handle_message(&message),
+                MessagePayload::Accepted(_) => proposer.handle_message(&message),
 
-            MessagePayload::Heartbeat(payload) => {
-                logger::log_debug(&format!(
-                    "[Coordinator] Handling HEARTBEAT: sender: {:?}, timestamp={}",
-                    payload.sender, payload.timestamp
-                ));
-                self.failure_detector
-                    .heartbeat(payload.sender.clone().node_id);
-
-                NetworkMessage {
-                    sender: self.node.clone(),
-                    payload: MessagePayload::Heartbeat(payload),
+                MessagePayload::RetryLearn(_) => {
+                    if !self.config.acceptors_send_learns {
+                        proposer.handle_message(&message)
+                    } else {
+                        acceptor.handle_message(&message)
+                    }
                 }
-            }
-            other_msg @ MessagePayload::ClientRequest(_)
-            | other_msg @ MessagePayload::ClientResponse(_)
-            | other_msg @ MessagePayload::Ignore => {
-                logger::log_warn(&format!(
-                    "[Coordinator] Received irrelevant message type: {:?}",
-                    other_msg
-                ));
-                ignore_msg
-            }
+
+                MessagePayload::Executed(_) => {
+                    if self.node.role != PaxosRole::Coordinator {
+                        proposer.handle_message(&message);
+                    }
+                    //* Not needed by non-leader coordinators due to them having access to "adu" through their learners */
+                    ignore_msg
+                }
+
+                MessagePayload::Prepare(_) => acceptor.handle_message(&message),
+                MessagePayload::Accept(_) => acceptor.handle_message(&message),
+
+                MessagePayload::Learn(_) => learner.handle_message(&message),
+
+                MessagePayload::Heartbeat(payload) => {
+                    logger::log_debug(&format!(
+                        "[Coordinator] Handling HEARTBEAT: sender: {:?}, timestamp={}",
+                        payload.sender, payload.timestamp
+                    ));
+                    self.failure_detector
+                        .heartbeat(payload.sender.clone().node_id);
+
+                    NetworkMessage {
+                        sender: self.node.clone(),
+                        payload: MessagePayload::Heartbeat(payload),
+                    }
+                }
+                other_msg @ MessagePayload::ClientRequest(_)
+                | other_msg @ MessagePayload::ClientResponse(_)
+                | other_msg @ MessagePayload::Ignore => {
+                    logger::log_warn(&format!(
+                        "[Coordinator] Received irrelevant message type: {:?}",
+                        other_msg
+                    ));
+                    ignore_msg
+                }
+            },
         }
     }
 
     /// Expose a snapshot of the current Paxos state.
     /// This aggregates the learner state (learned entries) and the key/value store state.
     fn get_state(&self) -> PaxosState {
-        let (learner_state, kv_state) = self.learner_agent.get_state();
+        let (learner_state, kv_state) = self.learner().get_state();
         PaxosState {
             learned: learner_state.learned,
             kv_state,
@@ -369,7 +459,7 @@ impl GuestPaxosCoordinatorResource for MyPaxosCoordinatorResource {
         if let Some(leader) = new_lead {
             logger::log_warn(&format!("Leader {} change initiated. New leader", &leader));
             if leader == self.node.node_id {
-                self.proposer_agent.become_leader();
+                self.proposer().become_leader();
             }
         }
     }


### PR DESCRIPTION
- Added cluster to config.yaml, that collects nodes to run in the same wasmtime host.
- Change run local script to use cluster id instead of node id
- Change config to use cluster instead of node
- Coalesce run_standalone and run_same_wasmtime into one function dynamically spawning nodes depending of content of cluster.
- Change Coordinator to only construct relevant Agents depending on its role.
- Ensure proper usage of Agents in Coordinator considering might not exist.
- Improve runner by having the leader wait some time before starting performing demo client work