### PR TITLE
Improve fault-tolerance and recovery

### DIFF
--- a/paxos-wasm/runner-ws/run-demo-client.sh
+++ b/paxos-wasm/runner-ws/run-demo-client.sh
@@ -13,7 +13,7 @@ BIN="./target/${TARGET}/modular-ws-client"
 # echo "Removing existing client log files..."'
 # rm -f "${LOG_DIR}/client"*.log
 
-TOTAL_REQUESTS=100000
+TOTAL_REQUESTS=1000000
 NUM_PROCESSES=10
 LOGICAL_CLIENTS_PER_PROCESS=50
 

--- a/paxos-wasm/runner-ws/src/config.yaml
+++ b/paxos-wasm/runner-ws/src/config.yaml
@@ -59,7 +59,7 @@ run_config:
   acceptors_send_learns: true
   learners_send_executed: true
   prepare_timeout: 100
-  demo_client: true
+  demo_client: false
   demo_client_requests: 123450
   batch_size: 20
   tick_micros: 100
@@ -68,8 +68,8 @@ run_config:
   learn_max_gap: 50
   message_batch_size: 20
   client_server_port: 60000
-  persistent_storage: false
-  heartbeats: false
+  persistent_storage: true
+  heartbeats: true
   heartbeat_interval_ms: 200
   # TODO: add configs for crashing, and hot reloading nodes
 

--- a/paxos-wasm/runner-ws/src/host_control.rs
+++ b/paxos-wasm/runner-ws/src/host_control.rs
@@ -1,0 +1,87 @@
+use std::sync::Mutex as StdMutex;
+use std::time::Instant;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::bindings::paxos::default::host_control::HostCmd;
+
+/// Internal ping metrics, all protected by a standard (blocking) Mutex.
+struct PingState {
+    first_ping: Option<Instant>,
+    last_ping_time: Option<Instant>,
+    ping_count: u64,
+}
+
+/// Holds exactly one queued HostCmd (e.g. Shutdown), plus simple “ping” metrics.
+/// Notice that both the command slot and the ping state are behind Mutexes.
+/// That way, `record_ping()` can take `&self` (not `&mut self`).
+pub struct HostControlHandler {
+    /// At most one pending command for the Runner to pick up.
+    command_slot: TokioMutex<Option<HostCmd>>,
+
+    /// Everything below is a little internal struct that tracks pings;
+    /// we wrap it in a `std::sync::Mutex` so that `record_ping(&self)` can lock it.
+    ping_state: StdMutex<PingState>,
+}
+
+impl HostControlHandler {
+    /// Create a new handler. Initially, no commands are queued and no pings seen.
+    pub fn new() -> Self {
+        HostControlHandler {
+            command_slot: TokioMutex::new(None),
+            ping_state: StdMutex::new(PingState {
+                first_ping: None,
+                last_ping_time: None,
+                ping_count: 0,
+            }),
+        }
+    }
+
+    /// Record that we got a ping “just now.” Updates first_ping, last_ping_time, and ping_count.
+    /// Can be called from `&self` even if `self` is wrapped in an Arc<…>.
+    pub async fn record_ping(&self) {
+        let now = Instant::now();
+
+        let mut inner = self.ping_state.lock().expect("ping_inner mutex poisoned");
+        if inner.first_ping.is_none() {
+            inner.first_ping = Some(now);
+        }
+        inner.ping_count += 1;
+        inner.last_ping_time = Some(now);
+
+        // Every 10_000 pings → calculate approximate pings/sec and log it
+        if inner.ping_count % 10_000 == 0 {
+            if let Some(first) = inner.first_ping {
+                let elapsed = now.duration_since(first);
+                let secs = elapsed.as_secs_f64().max(1e-9);
+                let rate = (inner.ping_count as f64) / secs;
+                tracing::warn!(
+                    "[Host Control] {} pings in {:.3?} → {:.2} ping/sec",
+                    inner.ping_count,
+                    elapsed,
+                    rate
+                );
+            }
+        }
+    }
+
+    /// Return the timestamp of the last ping, if any.
+    /// Can be called from `&self`.
+    pub async fn last_ping_time(&self) -> Option<Instant> {
+        let inner = self.ping_state.lock().expect("ping_inner mutex poisoned");
+        inner.last_ping_time
+    }
+
+    /// Called by the Runner to ask “does the Host have any command queued?”
+    /// If so, pop and return it. Otherwise return None.
+    pub async fn get_command(&self) -> Option<HostCmd> {
+        let mut guard = self.command_slot.lock().await;
+        guard.take()
+    }
+
+    /// Called by host‐side code to enqueue a `Shutdown` for the Runner.
+    /// Next time `get_command()` is called, the Runner will see `Some(HostCmd::Shutdown)`.
+    pub async fn request_shutdown(&self) {
+        let mut guard = self.command_slot.lock().await;
+        *guard = Some(HostCmd::Shutdown);
+    }
+}

--- a/paxos-wasm/runner-ws/src/main.rs
+++ b/paxos-wasm/runner-ws/src/main.rs
@@ -1,6 +1,7 @@
 mod bindings;
 mod config;
 mod host_logger;
+mod host_control;
 mod paxos_wasm;
 mod run;
 

--- a/paxos-wasm/shared/wit/paxos.wit
+++ b/paxos-wasm/shared/wit/paxos.wit
@@ -68,8 +68,23 @@ interface runner {
     use paxos-types.{node, run-config};
     
     resource runner-resource {
-    constructor(node: node, nodes: list<node>, is-leader: bool, config: run-config);
+        constructor(node: node, nodes: list<node>, is-leader: bool, config: run-config);
 
-    run: func();
+        run: func();
     }
 }
+
+interface host-control {
+    enum host-cmd {
+        shutdown, // gracefully exit soon
+        // Reconfigure: record new run‐config, etc. 
+        // ChangeLogLevel: record a new log level, etc.
+    }
+
+    // Called by the Runner on an interval to tell the Host “I’m still running.”
+    ping: func();
+  
+    // Poll the Host for any pending host-cmd.
+    get-command: func() -> option<host-cmd>;
+  }
+  

--- a/paxos-wasm/shared/wit/worlds.wit
+++ b/paxos-wasm/shared/wit/worlds.wit
@@ -88,8 +88,9 @@ world paxos-runner-world {
     import network-client;
     import paxos-coordinator;
     
-    import logger;
     import storage;
+    import logger;
+    import host-control;
 
     export runner;
 }


### PR DESCRIPTION
- Fix failure detector to make node suspicion and deeming a node dead a two-step process.
- Add new host-control interface implemented by the host meant to provide a control communication channel for the Runner to allow for pinging Host signaling aliveness. Also potentially receive commands from the host such as  commencing with graceful shutdown.
- Implement host implementation for host-control and plug into Runner, also with other logic to have a timeout period where we might deem a node stuck/frozen or even just slow.
- Runner not queries the host-control interface in its event loop. Minimum overhead of this due to no payload to serialize and deserialize.
- Add functionality in Run to properly handle a slowed/stuck/frozen node using the host-control. Also now perform new restart when nodes exits cleanly allowing for hot-swap update logic to be implemented properly.